### PR TITLE
Rewrite configuration management

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,10 +26,35 @@ npm install -g mrm
 
 ## Usage
 
-* `mrm` — print list of tasks
-* `mrm <task>` — run a task
+Print a list available of tasks:
 
-(You need to create a configuration file first — see below.)
+```shell
+mrm
+```
+
+Run a task or alias
+
+```shell
+mrm <task or alias>
+mrm gitignore
+mrm license
+```
+
+Override config options (or run without a config file):
+
+```shell
+mrm license --config:name "Gandalf the Grey" --config:email "gandalf@middleearth.com" --config:url "http://middleearth.com"
+```
+
+## Usage via npx
+
+If you have npm 5.3 or newer you can use mrm without installation:
+
+```shell
+npx mrm
+npx mrm gitignore
+npx mrm license --config:name "Gandalf the Grey" --config:email "gandalf@middleearth.com" --config:url "http://middleearth.com"
+```
 
 ## Configuration
 
@@ -49,6 +74,8 @@ Create `~/.mrm/config.json` or `~/dotfiles/mrm/config.json`:
     }
 }
 ```
+
+*Config file isn’t required, you can also pass config options via command line.*
 
 ## Tasks
 

--- a/Readme.md
+++ b/Readme.md
@@ -32,12 +32,17 @@ Print a list available of tasks:
 mrm
 ```
 
-Run a task or alias
+Run a task or an alias
 
 ```shell
-mrm <task or alias>
 mrm gitignore
 mrm license
+```
+
+Run multiple tasks:
+
+```shell
+mrm gitignore license
 ```
 
 Override config options (or run without a config file):

--- a/Readme.md
+++ b/Readme.md
@@ -170,9 +170,11 @@ Create either `~/.mrm/<taskname>/index.js` or `~/dotfiles/mrm/<taskname>/index.j
 
 ```js
 const { /* ... */ } = require('mrm-core');
-module.exports = function(config) {
-  // config('name', 'default value') - config value
-  // config() - all config values
+module.exports = function(config, argv) {
+  config.require('name', 'email') // Mark config values as required
+  // config('name') - config value
+  // config('name', 'default value') - config value with a default value
+  // argv - command line arguments
 };
 module.exports.description = 'Task description';
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,12 @@ Override config options (or run without a config file):
 mrm license --config:name "Gandalf the Grey" --config:email "gandalf@middleearth.com" --config:url "http://middleearth.com"
 ```
 
+Custom config and tasks folder:
+
+```shell
+mrm license --dir ~/unicorn
+```
+
 ## Usage via npx
 
 If you have npm 5.3 or newer you can use mrm without installation:

--- a/bin/mrm.js
+++ b/bin/mrm.js
@@ -12,7 +12,7 @@ const isDirectory = require('is-directory');
 const updateNotifier = require('update-notifier');
 const padEnd = require('lodash/padEnd');
 const sortBy = require('lodash/sortBy');
-const { run, getConfig, getAllTasks } = require('../src/index');
+const { run, getConfig, getAllTasks, getBinaryName } = require('../src/index');
 const directories = require('../src/directories');
 
 const isMrmEror = err => err.constructor.name === 'MrmError';
@@ -80,12 +80,13 @@ function commandHelp() {
 }
 
 function getUsage() {
+	const bin = getBinaryName();
 	const commands = EXAMPLES.map(x => x[0] + x[1]);
 	const commandsWidth = longest(commands).length;
 	return EXAMPLES.map(([command, options, description]) =>
 		[
 			'   ',
-			chalk.bold('mrm'),
+			chalk.bold(bin),
 			chalk.cyan(command),
 			chalk.yellow(options),
 			padEnd('', commandsWidth - (command + options).length),

--- a/bin/mrm.js
+++ b/bin/mrm.js
@@ -9,6 +9,7 @@ const minimist = require('minimist');
 const chalk = require('chalk');
 const longest = require('longest');
 const isDirectory = require('is-directory');
+const listify = require('listify');
 const updateNotifier = require('update-notifier');
 const padEnd = require('lodash/padEnd');
 const sortBy = require('lodash/sortBy');
@@ -102,9 +103,7 @@ function getTasksList() {
 
 	return names
 		.map(name => {
-			const description = Array.isArray(tasks[name])
-				? `Runs ${tasks[name].join(', ')}`
-				: tasks[name];
+			const description = Array.isArray(tasks[name]) ? `Runs ${listify(tasks[name])}` : tasks[name];
 			return '    ' + chalk.bold(padEnd(name, nameColWidth)) + '  ' + description;
 		})
 		.join('\n');

--- a/bin/mrm.js
+++ b/bin/mrm.js
@@ -39,7 +39,7 @@ process.on('uncaughtException', err => {
 });
 
 const argv = minimist(process.argv.slice(2));
-const command = argv._[0];
+const tasks = argv._;
 
 // Custom config / tasks directory
 if (argv.dir) {
@@ -53,12 +53,11 @@ if (argv.dir) {
 }
 
 const options = getConfig(directories, 'config.json', argv);
-
-if (command === 'help' || !command) {
+if (tasks.length === 0 || tasks[0] === 'help') {
 	commandHelp();
 } else {
 	try {
-		run(command, directories, options, argv);
+		run(tasks, directories, options, argv);
 	} catch (err) {
 		if (isMrmEror(err) && /(Alias|Task) ".*?" not found/.test(err.message)) {
 			printError(err.message);

--- a/bin/mrm.js
+++ b/bin/mrm.js
@@ -104,7 +104,7 @@ function getTasksList() {
 	return names
 		.map(name => {
 			const description = Array.isArray(tasks[name]) ? `Runs ${listify(tasks[name])}` : tasks[name];
-			return '    ' + chalk.bold(padEnd(name, nameColWidth)) + '  ' + description;
+			return '    ' + chalk.cyan(padEnd(name, nameColWidth)) + '  ' + description;
 		})
 		.join('\n');
 }

--- a/bin/mrm.js
+++ b/bin/mrm.js
@@ -17,6 +17,13 @@ const directories = require('../src/directories');
 
 const isMrmEror = err => err.constructor.name === 'MrmError';
 
+const EXAMPLES = [
+	['', '', 'List of available tasks'],
+	['<task or alias>', '', 'Run a task or an alias'],
+	['<task or alias>', '--dir ~/unicorn', 'Custom config and tasks folder'],
+	['<task or alias>', '--config:foo coffee --config:bar pizza', 'Override config options'],
+];
+
 // Update notifier
 const pkg = require('../package.json');
 updateNotifier({ pkg }).notify();
@@ -65,27 +72,26 @@ function commandHelp() {
 	console.log(
 		[
 			chalk.underline('Usage'),
-			'',
-			'    ' + chalk.bold('mrm') + ' ' + chalk.cyan('<task or alias>'),
-			'    ' +
-				chalk.bold('mrm') +
-				' ' +
-				chalk.cyan('<task or alias>') +
-				' ' +
-				chalk.yellow('--dir ~/unicorn'),
-			'    ' +
-				chalk.bold('mrm') +
-				' ' +
-				chalk.cyan('<task or alias>') +
-				' ' +
-				chalk.yellow('--config:foo coffee --config:bar pizza'),
-			'',
+			getUsage(),
 			chalk.underline('Available tasks'),
-			'',
 			getTasksList(options),
-			'',
-		].join('\n')
+		].join('\n\n')
 	);
+}
+
+function getUsage() {
+	const commands = EXAMPLES.map(x => x[0] + x[1]);
+	const commandsWidth = longest(commands).length;
+	return EXAMPLES.map(([command, options, description]) =>
+		[
+			'   ',
+			chalk.bold('mrm'),
+			chalk.cyan(command),
+			chalk.yellow(options),
+			padEnd('', commandsWidth - (command + options).length),
+			description && `# ${description}`,
+		].join(' ')
+	).join('\n');
 }
 
 function getTasksList() {

--- a/bin/mrm.js
+++ b/bin/mrm.js
@@ -20,9 +20,9 @@ const isMrmEror = err => err.constructor.name === 'MrmError';
 
 const EXAMPLES = [
 	['', '', 'List of available tasks'],
-	['<task or alias>', '', 'Run a task or an alias'],
-	['<task or alias>', '--dir ~/unicorn', 'Custom config and tasks folder'],
-	['<task or alias>', '--config:foo coffee --config:bar pizza', 'Override config options'],
+	['<task>', '', 'Run a task or an alias'],
+	['<task>', '--dir ~/unicorn', 'Custom config and tasks folder'],
+	['<task>', '--config:foo coffee --config:bar pizza', 'Override config options'],
 ];
 
 // Update notifier

--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,6 +2233,11 @@
         "ci-info": "1.0.0"
       }
     },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3534,6 +3534,14 @@
         "regex-cache": "0.4.3"
       }
     },
+    "middleearth-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/middleearth-names/-/middleearth-names-1.1.0.tgz",
+      "integrity": "sha1-wdXuSN77NoEo+66/686IR80Y3f8=",
+      "requires": {
+        "unique-random-array": "1.0.0"
+      }
+    },
     "mime": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
@@ -3590,9 +3598,9 @@
       }
     },
     "mrm-core": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-2.1.1.tgz",
-      "integrity": "sha1-g02EsxLSNv+cWZQIo6sPEuLohH4=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-2.1.3.tgz",
+      "integrity": "sha1-4LRttG0vSb8xvf3LqAf51O+7Z5U=",
       "requires": {
         "babel-code-frame": "6.22.0",
         "chalk": "1.1.3",
@@ -5215,6 +5223,19 @@
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
       "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk=",
       "dev": true
+    },
+    "unique-random": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
+      "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ="
+    },
+    "unique-random-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.0.tgz",
+      "integrity": "sha1-QrNyHFeTiNi2Z8k8Lb3j1dgakTY=",
+      "requires": {
+        "unique-random": "1.0.0"
+      }
     },
     "unique-string": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "glob": "^7.1.2",
+    "is-directory": "^0.3.1",
     "lodash": "^4.17.4",
     "longest": "^2.0.1",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chalk": "^2.0.1",
     "glob": "^7.1.2",
     "is-directory": "^0.3.1",
+    "listify": "^1.0.0",
     "lodash": "^4.17.4",
     "longest": "^2.0.1",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "listify": "^1.0.0",
     "lodash": "^4.17.4",
     "longest": "^2.0.1",
+    "middleearth-names": "^1.1.0",
     "minimist": "^1.2.0",
-    "mrm-core": "^2.1.1",
+    "mrm-core": "^2.1.3",
     "semver-utils": "^1.1.1",
     "update-notifier": "^2.2.0",
     "user-home": "^2.0.0"

--- a/src/__mocks__/directories.js
+++ b/src/__mocks__/directories.js
@@ -1,9 +1,0 @@
-// @ts-check
-'use strict';
-
-const path = require('path');
-
-module.exports = [
-	path.resolve(__dirname, '../../test/dir1'),
-	path.resolve(__dirname, '../../test/dir2'),
-];

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -199,6 +199,12 @@ describe('run', () => {
 		expect(task2).toHaveBeenCalledTimes(0);
 		expect(task3).toHaveBeenCalledTimes(1);
 	});
+
+	it('should run multiple tasks', () => {
+		run(['task1', 'task2'], directories, optionsWithAliases, {});
+		expect(task1).toHaveBeenCalledTimes(1);
+		expect(task2).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe('getAllAliases', () => {

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -14,7 +14,6 @@ const {
 	run,
 	getAllAliases,
 	getAllTasks,
-	getBinaryName,
 } = require('../index');
 const task1 = require('../../test/dir1/task1');
 const task2 = require('../../test/dir1/task2');
@@ -108,33 +107,34 @@ describe('getConfig', () => {
 });
 
 describe('getConfigGetter', () => {
-	it('should return a function', () => {
-		const result = getConfigGetter({}, 'pizza', directories);
+	it('should return an API', () => {
+		const result = getConfigGetter({});
 		expect(result).toEqual(expect.any(Function));
+		expect(result.require).toEqual(expect.any(Function));
 	});
 
-	it('should return a full config object if a property name wasn’t passed', () => {
-		const config = getConfigGetter(options, 'pizza', directories);
-		const result = config();
-		expect(result).toEqual(options);
-	});
-
-	it('function should return a config option value', () => {
-		const config = getConfigGetter(options, 'pizza', directories);
+	it('config function should return a config option value', () => {
+		const config = getConfigGetter(options);
 		const result = config('pizza');
 		expect(result).toBe('salami');
 	});
 
-	it('function should return a default valueif if a config option is not defined', () => {
-		const config = getConfigGetter({}, 'pizza', directories);
+	it('config function should return a default valueif if a config option is not defined', () => {
+		const config = getConfigGetter({});
 		const result = config('pizza', 'salami');
 		expect(result).toBe('salami');
 	});
 
-	it('function should throw if a config option not defined and no default value provided', () => {
-		const config = getConfigGetter({}, 'pizza', directories);
-		const fn = () => config('pizza');
-		expect(fn).toThrowError('Config option "pizza" is not defined');
+	it('require function should not throw if all config options are difended', () => {
+		const config = getConfigGetter({ coffee: 'americano' });
+		const fn = () => config.require('coffee');
+		expect(fn).not.toThrowError();
+	});
+
+	it('require function should throw if some config options are not difended', () => {
+		const config = getConfigGetter({ coffee: 'americano' });
+		const fn = () => config.require('pizza', 'coffee');
+		expect(fn).toThrowError('Required config options are missed: pizza');
 	});
 });
 
@@ -152,7 +152,7 @@ describe('runTask', () => {
 		const params = { coffee: 'cappuccino' };
 		runTask('task1', directories, options, params);
 		expect(task1).toHaveBeenCalledWith(expect.any(Function), params);
-		expect(task1.mock.calls[0][0]()).toEqual(options);
+		expect(task1.mock.calls[0][0]('pizza')).toEqual('salami');
 	});
 
 	it('should throw when module not found', () => {
@@ -230,22 +230,5 @@ describe('getAllTasks', () => {
 			task2: 'Taks 1.2',
 			task3: 'Taks 2.3',
 		});
-	});
-});
-
-describe('getBinaryName', () => {
-	it('should return a binary name', () => {
-		const result = getBinaryName();
-		expect(result).toBe('mrm');
-	});
-
-	it('should return a binary name if ran via npx', () => {
-		const _ = process.env._;
-		process.env._ = '/bin/npx';
-
-		const result = getBinaryName();
-		expect(result).toBe('npx mrm');
-
-		process.env._ = _;
 	});
 });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -2,102 +2,221 @@
 'use strict';
 /* eslint-disable no-console */
 
-jest.mock('../directories');
-
 const path = require('path');
-const { tryFile, getConfig, config, runTask, runAlias, getAllTasks } = require('../index');
+const {
+	tryFile,
+	getConfigFromFile,
+	getConfigFromCommandLine,
+	getConfig,
+	getConfigGetter,
+	runTask,
+	runAlias,
+	run,
+	getAllAliases,
+	getAllTasks,
+} = require('../index');
 const task1 = require('../../test/dir1/task1');
 const task2 = require('../../test/dir1/task2');
 const task3 = require('../../test/dir2/task3');
+
+const configFile = 'config.json';
+const directories = [
+	path.resolve(__dirname, '../../test/dir1'),
+	path.resolve(__dirname, '../../test/dir2'),
+];
+const options = {
+	pizza: 'salami',
+};
+const optionsWithAliases = {
+	aliases: {
+		alias1: ['task1', 'task3'],
+	},
+};
+const argv = {
+	_: [],
+	div: '~/pizza',
+	'config:foo': 42,
+	'config:bar': 'coffee',
+};
 
 const file = name => path.join(__dirname, '../../test', name);
 
 describe('tryFile', () => {
 	it('should return an absolute file path if the file exists', () => {
-		expect(tryFile('task1/index.js')).toBe(file('dir1/task1/index.js'));
-		expect(tryFile('task3/index.js')).toBe(file('dir2/task3/index.js'));
+		expect(tryFile(directories, 'task1/index.js')).toBe(file('dir1/task1/index.js'));
+		expect(tryFile(directories, 'task3/index.js')).toBe(file('dir2/task3/index.js'));
 	});
 
 	it('should return undefined if the file doesn’t exist', () => {
-		const result = tryFile('pizza');
+		const result = tryFile([], 'pizza');
 		expect(result).toBeFalsy();
+	});
+});
+
+describe('getConfigFromFile', () => {
+	it('should return a config object', () => {
+		const result = getConfigFromFile(directories, configFile);
+		expect(result).toMatchObject(options);
+	});
+
+	it('should return an empty object when file not found', () => {
+		const result = getConfigFromFile(directories, 'pizza');
+		expect(result).toEqual({});
+	});
+});
+
+describe('getConfigFromCommandLine', () => {
+	it('should return a config object', () => {
+		const result = getConfigFromCommandLine(argv);
+		expect(result).toEqual({
+			foo: 42,
+			bar: 'coffee',
+		});
+	});
+
+	it('should return an empty object when no config options found', () => {
+		const result = getConfigFromCommandLine({
+			_: [],
+			div: '~/pizza',
+		});
+		expect(result).toEqual({});
 	});
 });
 
 describe('getConfig', () => {
 	it('should return a config object', () => {
-		const result = getConfig();
-		expect(result).toMatchObject({ pizza: 'salami' });
+		const result = getConfig(directories, configFile, argv);
+		expect(result).toMatchObject({
+			pizza: 'salami',
+			foo: 42,
+			bar: 'coffee',
+		});
 	});
 
-	it('should throw when file not found', () => {
-		const fn = () => getConfig('pizza');
-		expect(fn).toThrowError('not found');
+	it('should return an empty object when file not found and no CLI options provided', () => {
+		const result = getConfig(directories, 'pizza', {});
+		expect(result).toEqual({});
+	});
+
+	it('CLI options should override options from config file', () => {
+		const result = getConfig(directories, configFile, { 'config:pizza': 'quattro formaggi' });
+		expect(result).toMatchObject({
+			pizza: 'quattro formaggi',
+		});
 	});
 });
 
-describe('config', () => {
-	it('should return a config object', () => {
-		const result = config();
-		expect(result).toMatchObject({ pizza: 'salami' });
+describe('getConfigGetter', () => {
+	it('should return a function', () => {
+		const result = getConfigGetter({});
+		expect(result).toEqual(expect.any(Function));
 	});
 
-	it('should return a config option value', () => {
+	it('should return a full config object if a property name wasn’t passed', () => {
+		const config = getConfigGetter(options);
+		const result = config();
+		expect(result).toEqual(options);
+	});
+
+	it('function should return a config option value', () => {
+		const config = getConfigGetter(options);
 		const result = config('pizza');
 		expect(result).toBe('salami');
 	});
 
-	it('should return a default value when option is not defined', () => {
-		const result = config('coffee', 'americano');
-		expect(result).toBe('americano');
+	it('function should return a default valueif if a config option is not defined', () => {
+		const config = getConfigGetter({});
+		const result = config('pizza', 'salami');
+		expect(result).toBe('salami');
+	});
+
+	it('function should throw if a config option not defined and no default value provided', () => {
+		const config = getConfigGetter({});
+		const fn = () => config('pizza');
+		expect(fn).toThrowError('Config option "pizza" not defined');
 	});
 });
 
 describe('runTask', () => {
-	afterAll(() => {
+	beforeEach(() => {
 		task1.mockClear();
 	});
 
 	it('should run a module', () => {
-		runTask('task1');
+		runTask('task1', directories, {}, {});
 		expect(task1).toHaveBeenCalledTimes(1);
 	});
 
 	it('should pass a config function and a params object to a module', () => {
 		const params = { coffee: 'cappuccino' };
-		runTask('task1', params);
+		runTask('task1', directories, options, params);
 		expect(task1).toHaveBeenCalledWith(expect.any(Function), params);
+		expect(task1.mock.calls[0][0]()).toEqual(options);
 	});
 
 	it('should throw when module not found', () => {
-		const fn = () => runTask('pizza');
+		const fn = () => runTask('pizza', directories, {}, {});
 		expect(fn).toThrowError('not found');
 	});
 });
 
 describe('runAlias', () => {
-	afterAll(() => {
+	beforeEach(() => {
 		task1.mockClear();
 		task2.mockClear();
 		task3.mockClear();
 	});
 
 	it('should run all tasks defined in an alias', () => {
-		runAlias('alias1');
+		runAlias('alias1', directories, optionsWithAliases, {});
 		expect(task1).toHaveBeenCalledTimes(1);
 		expect(task2).toHaveBeenCalledTimes(0);
 		expect(task3).toHaveBeenCalledTimes(1);
 	});
 
 	it('should throw when alias not found', () => {
-		const fn = () => runAlias('pizza');
+		const fn = () => runAlias('pizza', directories, optionsWithAliases, {});
 		expect(fn).toThrowError('not found');
 	});
 });
 
-describe('getAllTasks', () => {
+describe('run', () => {
+	beforeEach(() => {
+		task1.mockClear();
+		task2.mockClear();
+		task3.mockClear();
+	});
+
+	it('should run a task', () => {
+		run('task1', directories, optionsWithAliases, {});
+		expect(task1).toHaveBeenCalledTimes(1);
+	});
+
 	it('should run all tasks defined in an alias', () => {
-		const result = getAllTasks();
+		run('alias1', directories, optionsWithAliases, {});
+		expect(task1).toHaveBeenCalledTimes(1);
+		expect(task2).toHaveBeenCalledTimes(0);
+		expect(task3).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('getAllAliases', () => {
+	it('should return all aliases', () => {
+		const result = getAllAliases(optionsWithAliases);
+		expect(result).toEqual({
+			alias1: ['task1', 'task3'],
+		});
+	});
+
+	it('should return an empty object when no aliases defined', () => {
+		const result = getAllAliases(options);
+		expect(result).toEqual({});
+	});
+});
+
+describe('getAllTasks', () => {
+	it('should return all available tasks', () => {
+		const result = getAllTasks(directories, optionsWithAliases);
 		expect(result).toEqual({
 			alias1: ['task1', 'task3'],
 			task1: 'Taks 1.1',

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -108,30 +108,30 @@ describe('getConfig', () => {
 
 describe('getConfigGetter', () => {
 	it('should return a function', () => {
-		const result = getConfigGetter({}, 'pizza');
+		const result = getConfigGetter({}, 'pizza', directories);
 		expect(result).toEqual(expect.any(Function));
 	});
 
 	it('should return a full config object if a property name wasn’t passed', () => {
-		const config = getConfigGetter(options, 'pizza');
+		const config = getConfigGetter(options, 'pizza', directories);
 		const result = config();
 		expect(result).toEqual(options);
 	});
 
 	it('function should return a config option value', () => {
-		const config = getConfigGetter(options, 'pizza');
+		const config = getConfigGetter(options, 'pizza', directories);
 		const result = config('pizza');
 		expect(result).toBe('salami');
 	});
 
 	it('function should return a default valueif if a config option is not defined', () => {
-		const config = getConfigGetter({}, 'pizza');
+		const config = getConfigGetter({}, 'pizza', directories);
 		const result = config('pizza', 'salami');
 		expect(result).toBe('salami');
 	});
 
 	it('function should throw if a config option not defined and no default value provided', () => {
-		const config = getConfigGetter({}, 'pizza');
+		const config = getConfigGetter({}, 'pizza', directories);
 		const fn = () => config('pizza');
 		expect(fn).toThrowError('Config option "pizza" is not defined');
 	});

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -108,32 +108,32 @@ describe('getConfig', () => {
 
 describe('getConfigGetter', () => {
 	it('should return a function', () => {
-		const result = getConfigGetter({});
+		const result = getConfigGetter({}, 'pizza');
 		expect(result).toEqual(expect.any(Function));
 	});
 
 	it('should return a full config object if a property name wasn’t passed', () => {
-		const config = getConfigGetter(options);
+		const config = getConfigGetter(options, 'pizza');
 		const result = config();
 		expect(result).toEqual(options);
 	});
 
 	it('function should return a config option value', () => {
-		const config = getConfigGetter(options);
+		const config = getConfigGetter(options, 'pizza');
 		const result = config('pizza');
 		expect(result).toBe('salami');
 	});
 
 	it('function should return a default valueif if a config option is not defined', () => {
-		const config = getConfigGetter({});
+		const config = getConfigGetter({}, 'pizza');
 		const result = config('pizza', 'salami');
 		expect(result).toBe('salami');
 	});
 
 	it('function should throw if a config option not defined and no default value provided', () => {
-		const config = getConfigGetter({});
+		const config = getConfigGetter({}, 'pizza');
 		const fn = () => config('pizza');
-		expect(fn).toThrowError('Config option "pizza" not defined');
+		expect(fn).toThrowError('Config option "pizza" is not defined');
 	});
 });
 

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -14,6 +14,7 @@ const {
 	run,
 	getAllAliases,
 	getAllTasks,
+	getBinaryName,
 } = require('../index');
 const task1 = require('../../test/dir1/task1');
 const task2 = require('../../test/dir1/task2');
@@ -223,5 +224,22 @@ describe('getAllTasks', () => {
 			task2: 'Taks 1.2',
 			task3: 'Taks 2.3',
 		});
+	});
+});
+
+describe('getBinaryName', () => {
+	it('should return a binary name', () => {
+		const result = getBinaryName();
+		expect(result).toBe('mrm');
+	});
+
+	it('should return a binary name if ran via npx', () => {
+		const _ = process.env._;
+		process.env._ = '/bin/npx';
+
+		const result = getBinaryName();
+		expect(result).toBe('npx mrm');
+
+		process.env._ = _;
 	});
 });

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,28 @@
+// @ts-check
+'use strict';
+
+class MrmUnknownTask extends Error {
+	constructor(message) {
+		super(message);
+		Object.defineProperty(this, 'name', {
+			value: this.constructor.name,
+		});
+	}
+}
+
+class MrmUndefinedOption extends Error {
+	constructor(message, extra) {
+		super(message);
+		Object.defineProperty(this, 'name', {
+			value: this.constructor.name,
+		});
+		Object.defineProperty(this, 'extra', {
+			value: extra,
+		});
+	}
+}
+
+module.exports = {
+	MrmUnknownTask,
+	MrmUndefinedOption,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ In one of these folders:
 
 2. Or pass the option via command line:
 
-  mrm ${taskName} --config:${prop} "Gandalf the Grey"
+  ${getBinaryName()} ${taskName} --config:${prop} "Gandalf the Grey"
 `
 			);
 		}
@@ -207,6 +207,15 @@ function tryFile(directories, filename) {
 	return undefined;
 }
 
+/**
+ * Detect that mrm was ran using npx, return either "mrm" or "npx mrm".
+ *
+ * @return {string}
+ */
+function getBinaryName() {
+	return process.env._.endsWith('/npx') ? 'npx mrm' : 'mrm';
+}
+
 module.exports = {
 	getAllAliases,
 	getAllTasks,
@@ -218,4 +227,5 @@ module.exports = {
 	getConfigFromFile,
 	getConfigFromCommandLine,
 	tryFile,
+	getBinaryName,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,8 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 const chalk = require('chalk');
-const get = require('lodash/get');
-const forEach = require('lodash/forEach');
-const { MrmError } = require('mrm-core');
+const { get, forEach } = require('lodash');
+const { MrmUnknownTask, MrmUndefinedOption } = require('./errors');
 
 /* eslint-disable no-console */
 
@@ -73,7 +72,7 @@ function run(name, directories, options, argv) {
 function runAlias(aliasName, directories, options, argv) {
 	const tasks = getAllAliases(options)[aliasName];
 	if (!tasks) {
-		throw new MrmError(`Alias "${aliasName}" not found.`);
+		throw new MrmUnknownTask(`Alias "${aliasName}" not found.`);
 	}
 
 	console.log(chalk.yellow(`Running alias ${aliasName}...`));
@@ -92,7 +91,7 @@ function runAlias(aliasName, directories, options, argv) {
 function runTask(taskName, directories, options, argv) {
 	const filename = tryFile(directories, `${taskName}/index.js`);
 	if (!filename) {
-		throw new MrmError(`Task "${taskName}" not found.`);
+		throw new MrmUnknownTask(`Task "${taskName}" not found.`);
 	}
 
 	console.log(chalk.cyan(`Running ${taskName}...`));
@@ -127,7 +126,9 @@ function getConfigGetter(options) {
 	function require(...names) {
 		const unknown = names.filter(name => !(name in options));
 		if (unknown.length > 0) {
-			throw new MrmError(`Required config options are missed: ${unknown.join(', ')}.`, unknown);
+			throw new MrmUndefinedOption(`Required config options are missed: ${unknown.join(', ')}.`, {
+				unknown,
+			});
 		}
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,12 +44,17 @@ function getAllAliases(options) {
 
 /**
  *
- * @param {string} name
+ * @param {string|string[]} name
  * @param {string[]} directories
  * @param {Object} options
  * @param {Object} argv
  */
 function run(name, directories, options, argv) {
+	if (Array.isArray(name)) {
+		name.forEach(n => run(n, directories, options, argv));
+		return;
+	}
+
 	if (getAllAliases(options)[name]) {
 		runAlias(name, directories, options, argv);
 	} else {

--- a/src/index.js
+++ b/src/index.js
@@ -93,16 +93,17 @@ function runTask(taskName, directories, options, argv) {
 	console.log(chalk.cyan(`Running ${taskName}...`));
 
 	const module = require(filename);
-	module(getConfigGetter(options), argv);
+	module(getConfigGetter(options, taskName), argv);
 }
 
 /**
  * Return a config getter.
  *
  * @param {Object} options
+ * @param {string} taskName
  * @return {Function}
  */
-function getConfigGetter(options) {
+function getConfigGetter(options, taskName) {
 	/**
 	 * Return a config value.
 	 *
@@ -118,13 +119,17 @@ function getConfigGetter(options) {
 		const value = get(options, prop, defaultValue);
 		if (value === undefined && defaultValue === undefined) {
 			throw new MrmError(
-				`Config option "${prop}" not defined.
+				`Config option "${prop}" is not defined.
 
-Create "~/.mrm/config.json" or "~/dotfiles/mrm/config.json" file.
+Create "~/.mrm/config.json" or "~/dotfiles/mrm/config.json" file:
 
-Or pass options via command line:
+  {
+    "${prop}": "Gandalf the Grey"
+  }
 
-  mrm license --config:name "Gandalf the Grey" --config:email "gandalf@middleearth.com" --config:url "http://middleearth.com"
+Or pass the option via command line:
+
+  mrm ${taskName} --config:${prop} "Gandalf the Grey"
 `
 			);
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ function runTask(taskName, directories, options, argv) {
 	console.log(chalk.cyan(`Running ${taskName}...`));
 
 	const module = require(filename);
-	module(getConfigGetter(options, taskName), argv);
+	module(getConfigGetter(options, taskName, directories), argv);
 }
 
 /**
@@ -101,9 +101,10 @@ function runTask(taskName, directories, options, argv) {
  *
  * @param {Object} options
  * @param {string} taskName
+ * @param {string[]} directories
  * @return {Function}
  */
-function getConfigGetter(options, taskName) {
+function getConfigGetter(options, taskName, directories) {
 	/**
 	 * Return a config value.
 	 *
@@ -121,13 +122,17 @@ function getConfigGetter(options, taskName) {
 			throw new MrmError(
 				`Config option "${prop}" is not defined.
 
-Create "~/.mrm/config.json" or "~/dotfiles/mrm/config.json" file:
+1. Create "config.json" file:
 
   {
     "${prop}": "Gandalf the Grey"
   }
 
-Or pass the option via command line:
+In one of these folders:
+
+- ${directories.slice(0, -1).join('\n- ')}
+
+2. Or pass the option via command line:
 
   mrm ${taskName} --config:${prop} "Gandalf the Grey"
 `

--- a/src/tasks/codecov/index.js
+++ b/src/tasks/codecov/index.js
@@ -6,6 +6,8 @@ const uploadCommand = 'bash <(curl -s https://codecov.io/bash)';
 const coverageScript = 'test:coverage';
 
 module.exports = function(config) {
+	config.require('github');
+
 	const travisYml = yaml('.travis.yml');
 
 	// Require .travis.yml

--- a/src/tasks/license/index.js
+++ b/src/tasks/license/index.js
@@ -20,7 +20,10 @@ function task(config) {
 	}
 
 	template(filename, templateFile)
-		.apply(config(), {
+		.apply({
+			name: config('name'),
+			email: config('email'),
+			url: config('url'),
 			year: new Date().getFullYear(),
 		})
 		.save();

--- a/src/tasks/license/index.js
+++ b/src/tasks/license/index.js
@@ -8,6 +8,8 @@ const { template, packageJson } = require('mrm-core');
 const defaultLicense = 'mit';
 
 function task(config) {
+	config.require('name', 'email', 'url');
+
 	const filename = config('license', 'License.md');
 
 	const pkg = packageJson();

--- a/src/tasks/package/index.js
+++ b/src/tasks/package/index.js
@@ -4,6 +4,8 @@ const path = require('path');
 const { json } = require('mrm-core');
 
 module.exports = function(config) {
+	config.require('name', 'url', 'github');
+
 	const name = path.basename(process.cwd());
 	const github = `https://github.com/${config('github')}`;
 

--- a/src/tasks/readme/index.js
+++ b/src/tasks/readme/index.js
@@ -4,17 +4,19 @@ const path = require('path');
 const { template } = require('mrm-core');
 
 module.exports = function(config) {
+	config.require('name', 'url', 'github');
+
 	// Create Readme.md (no update)
 	const readme = template(config('readme', 'Readme.md'), path.join(__dirname, 'Readme.md'));
 	if (!readme.exists()) {
 		readme
-			.apply(
-				{
-					package: path.basename(process.cwd()),
-					license: config('license', 'License.md'),
-				},
-				config()
-			)
+			.apply({
+				name: config('name'),
+				url: config('url'),
+				github: config('github'),
+				license: config('license', 'License.md'),
+				package: path.basename(process.cwd()),
+			})
 			.save();
 	}
 };

--- a/src/tasks/stylelint/index.js
+++ b/src/tasks/stylelint/index.js
@@ -14,7 +14,7 @@ module.exports = function(config) {
 			.merge({
 				extends: preset,
 				rules: {
-					indentation: config('indent'),
+					indentation: config('indent', 'tab'),
 					'selector-pseudo-class-no-unknown': [
 						true,
 						{

--- a/src/tasks/travis/index.js
+++ b/src/tasks/travis/index.js
@@ -8,6 +8,8 @@ const { yaml, json, markdown } = require('mrm-core');
 const latestNodeVersion = 8;
 
 module.exports = function(config) {
+	config.require('github');
+
 	const pkg = json('package.json');
 
 	// .travis.yml


### PR DESCRIPTION
- Do not require config file.
- Validate each config option separately.
- Throw only if options is not difined and no default value provided.
- Allow overriding config options via command line.

Todo:

- [x] Specify config/tasks folder from a command line (#9)
- [x] Run multiple tasks (#8)