### PR TITLE
Guard against absence of the "_" env var

### DIFF
--- a/bin/mrm.js
+++ b/bin/mrm.js
@@ -41,7 +41,8 @@ process.on('uncaughtException', err => {
 const argv = minimist(process.argv.slice(2));
 const tasks = argv._;
 
-const binaryName = process.env._.endsWith('/npx') ? 'npx mrm' : 'mrm';
+const binaryPath = process.env._;
+const binaryName = binaryPath && binaryPath.endsWith('/npx') ? 'npx mrm' : 'mrm';
 
 // Custom config / tasks directory
 if (argv.dir) {


### PR DESCRIPTION
There is no guarantee the `_` variable is available in the shell. At least in PowerShell it isn't, and it was throwing errors at me. Otherwise mrm seems to work fine on Windows.

There is still a minor downside though: in case the var doesn't exist, the printed binary name will always be `mrm` even when used via npx.