### PR TITLE
feat: Finish interactive mode

### DIFF
--- a/docs/Writing_tasks.md
+++ b/docs/Writing_tasks.md
@@ -45,14 +45,14 @@ npm init -y
 npm install --save mrm-core
 ```
 
-[mrm-core](../packages/mrm-core) is an utility library created to write Mrm tasks, it has functions to work with common config files (JSON, YAML, INI, Markdown), npm dependencies, etc.
+[mrm-core](../packages/mrm-core) is an utility library for writing Mrm tasks, it has functions to work with common config files (JSON, YAML, INI, Markdown), npm dependencies, etc.
 
 ## With `mrm-core` and parameters
 
 Let’s take a look at a more complex task.
 
 ```js
-// 1 - Import utility helpers (could use any NPM package here).
+// Import utility helpers (could use any npm package here).
 const {
   // JSON files
   json,
@@ -64,75 +64,187 @@ const {
   install
 } = require('mrm-core');
 
-// 2 - Define task configuration.
-// Follows "inquirer" prompt definition.
-const parameters = {
-  eslintPreset: {
-    type: 'input',
-    message: 'ESLint preset to use as basis',
-    initial: 'eslint:recommended'
-  }
-};
-
-function task(config) {
-  // 3 - Load task configs (either from prompt or other methods).
-  const { eslintPreset } = config.values();
-
-  // 4 - Define packages to install.
+// task() function gets task parameters object as the first argument
+// (see `module.exports.parameters` at the end of the file).
+module.exports = function task({ eslintPreset }) {
+  // Define packages to install.
   const packages = ['eslint'];
 
-  // 5 - Append custom eslint-config in case defined.
+  // Append custom eslint-config in case it's defined.
   if (eslintPreset !== 'eslint:recommended') {
     packages.push(`eslint-config-${eslintPreset}`);
   }
 
-  // 6 - Create or load .eslintignore, and set basic ignores.
+  // Create or load .eslintignore, and set basic ignores.
   lines('.eslintignore')
     .add(['node_modules/'])
     .save();
 
-  // 7 - Create or load package.json.
+  // Create or load package.json.
   const pkg = packageJson();
 
   pkg
-    // 8 - Set linting script.
+    // Set linting script.
     .setScript('lint', 'eslint . --cache --fix')
-    // 9 - Set pretest script.
+    // Set pretest script.
     .prependScript('pretest', 'npm run lint')
-    // 10 - Save changes to package.json.
+    // Save changes to package.json.
     .save();
 
-  // 11 - Create or load .eslintrc.
+  // Create or load .eslintrc.
   const eslintrc = json('.eslintrc');
 
-  // 12 - Use Babel parser if the project depends on Babel.
+  // Use Babel parser if the project depends on Babel.
   if (pkg.get('devDependencies.babel-core')) {
     const parser = 'babel-eslint';
     packages.push(parser);
     eslintrc.merge({ parser });
   }
 
-  // 13 - Configure ESlint preset, if set (defaults to eslint:recommended).
+  // Configure ESlint preset, if set (defaults to eslint:recommended).
   if (eslintPreset) {
     eslintrc.set('extends', eslintPreset);
   }
 
-  // 14 - Save changes to .eslintrc.
+  // Save changes to .eslintrc.
   eslintrc.save();
 
-  // 15 - Install new npm dependencies.
+  // Install new npm dependencies.
   install(packages);
-}
+};
 
-// 16 - Configure task metadata (used by the `mrm` tool).
-task.parameters = parameters;
-task.description = 'Adds ESLint';
+// Configure task metadata (used by the `mrm` tool).
 
-module.exports = task;
+// Define task configuration (see "Configuration prompts" section below for details)
+module.exports.parameters = {
+  // Follows Inquirer.js questions format.
+  eslintPreset: {
+    // input, number, confirm, list, rawlist, expand, checkbox, password, editor
+    type: 'input',
+    message: 'ESLint preset to use as basis',
+    default: 'eslint:recommended'
+  }
+};
+// Description to show in the task list
+module.exports.description = 'Adds ESLint';
 ```
 
-> Have a look at [`mrm-core` docs](../packages/mrm-core#api) for more utility helpers, and [the default tasks](../Readme.md#tasks) for reference.
+Have a look at [mrm-core docs](../packages/mrm-core#api) for more utility helpers, and [the default tasks](../Readme.md#tasks) for reference.
 
 ### Configuration prompts
 
-The example above shows a basic configuration prompt (`parameters`), but Mrm supports more complex prompts too. Have a look at [Inquirer docs](https://github.com/SBoudrias/Inquirer.js#documentation).
+The example above shows a basic configuration prompt:
+
+```js
+module.exports.parameters = {
+  eslintPreset: {
+    type: 'input',
+    message: 'ESLint preset to use as basis',
+    default: 'eslint:recommended'
+  }
+};
+```
+
+Mrm supports more complex prompts too — have a look at [Inquirer.js docs](https://github.com/SBoudrias/Inquirer.js#objects).
+
+We pass all parameters to Inquirer.js, unless they have the `config` type:
+
+```js
+module.exports.parameters = {
+  indent: {
+    type: 'config',
+    default: 'tab'
+  }
+};
+```
+
+The `default` can be a value, like in the example above, or a function that receives an object with config values and command line overrides:
+
+```js
+module.exports.parameters = {
+  spaces: {
+    type: 'input',
+    message: 'Number of spaces for tab stop',
+    default(options) {
+      return options.input || Math.round(Math.random() * 10);
+    }
+  }
+};
+```
+
+This is different from the default Inquirer.js behavior and works consistently in interactive and non-interactive modes.
+
+Use the `validate()` method to make a parameter required:
+
+```js
+module.exports.parameters = {
+  eslintPreset: {
+    type: 'input',
+    message: 'ESLint preset to use as basis',
+    validate(value) {
+      return value ? true : 'eslintPreset is required';
+    }
+  }
+};
+```
+
+In this case the only ways to override the default walue are a config file or a command line parameter.
+
+### Migrating from the legacy parameters to Inquirer.js
+
+Calling `.defaults()`, `.required()` and `.values()` on the parameters object is deprecated in mrm-core X.X.
+
+```js
+module.exports = function task(config) {
+  const {
+    indent,
+    prettierPattern,
+    prettierOptions,
+    prettierOverrides
+  } = config
+    .defaults({
+      indent: 'tab'
+    })
+    .values();
+  // ...
+};
+```
+
+Mrm passes parameters to the task function as a plain object:
+
+```js
+module.exports = function task({
+  indent,
+  prettierPattern,
+  prettierOptions,
+  prettierOverrides
+}) {
+  // ...
+};
+```
+
+Parameters are described using an [Inquirer.js](https://github.com/SBoudrias/Inquirer.js#objects) object:
+
+```js
+module.exports.parameters = {
+  indent: {
+    type: 'input',
+    message: 'Choose indentation style (tabs or number of spaces)',
+    default: 'tab',
+    choices: ['tab', 2, 4, 8]
+  },
+  prettierPattern: {
+    type: 'input',
+    message: 'Enter Prettier file glob pattern',
+    default: 'auto'
+  },
+  prettierOptions: {
+    type: 'config'
+  },
+  prettierOverrides: {
+    type: 'config'
+  }
+};
+```
+
+See the previous section for more examples.

--- a/packages/mrm-core/src/index.js
+++ b/packages/mrm-core/src/index.js
@@ -1,3 +1,4 @@
+// @ts-check
 const fs = require('./fs');
 const npm = require('./npm');
 const editorconfig = require('./editorconfig');

--- a/packages/mrm/package-lock.json
+++ b/packages/mrm/package-lock.json
@@ -53,61 +53,6 @@
 				"color-convert": "^1.9.0"
 			}
 		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"requires": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				},
-				"ansi-styles": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-				},
-				"chalk": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-				}
-			}
-		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -258,22 +203,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-		},
-		"comment-json": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/comment-json/-/comment-json-2.4.2.tgz",
-			"integrity": "sha512-T+iXox779qsqneMYx/x5BZyz4xjCeQRmuNVzz8tko7qZUs3MlzpA3RAs+O1XsgcKToNBMIvfVzafGOeiU7RggA==",
-			"requires": {
-				"core-util-is": "^1.0.2",
-				"esprima": "^4.0.1",
-				"has-own-prop": "^2.0.0",
-				"repeat-string": "^1.6.1"
-			}
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -291,11 +220,6 @@
 				"write-file-atomic": "^2.0.0",
 				"xdg-basedir": "^3.0.0"
 			}
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cross-spawn": {
 			"version": "5.1.0",
@@ -330,11 +254,6 @@
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
 			"integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ=="
 		},
-		"detect-indent": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-			"integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
-		},
 		"dot-prop": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -347,29 +266,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
 			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-		},
-		"editorconfig": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-			"requires": {
-				"commander": "^2.19.0",
-				"lru-cache": "^4.1.5",
-				"semver": "^5.6.0",
-				"sigmund": "^1.0.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
-		},
-		"editorconfig-to-prettier": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz",
-			"integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ=="
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -389,16 +285,6 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
-		"esprima": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-		},
-		"esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-		},
 		"execa": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -412,11 +298,6 @@
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
 			}
-		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "2.0.1",
@@ -444,29 +325,10 @@
 				"escape-string-regexp": "^1.0.5"
 			}
 		},
-		"find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"requires": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			}
-		},
 		"fs-exists-sync": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
 			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
-		},
-		"fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"requires": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -551,30 +413,10 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
 			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "^2.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-				}
-			}
-		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-		},
-		"has-own-prop": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
-			"integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
 		},
 		"has-yarn": {
 			"version": "2.1.0",
@@ -753,32 +595,10 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
-		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
-		},
-		"js-yaml": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			}
-		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
 			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-		},
-		"jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"requires": {
-				"graceful-fs": "^4.1.6"
-			}
 		},
 		"keyv": {
 			"version": "3.1.0",
@@ -805,14 +625,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
 			"integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM="
-		},
-		"locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"requires": {
-				"p-locate": "^4.1.0"
-			}
 		},
 		"lodash": {
 			"version": "4.17.15",
@@ -877,197 +689,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.2.tgz",
 			"integrity": "sha512-rIqbOrKb8GJmx/5bc2M0QchhUouMXSpd1RTclXsB41JdL+VtnojfaJR+h7F9k18/4kHUsBFgk80Uk+q569vjPA=="
 		},
-		"mrm-core": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.0.2.tgz",
-			"integrity": "sha512-BQFh9f5xXjR6UvqZSCvwDRWhGnzcmcEmwbkTLFFZmn4v8ClhJxyoCHQUsCRpCwNGcsMHkMlkHb8IERS5V7Frow==",
-			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"comment-json": "^2.2.0",
-				"detect-indent": "^6.0.0",
-				"editorconfig": "^0.15.3",
-				"find-up": "^4.1.0",
-				"fs-extra": "^8.1.0",
-				"js-yaml": "^3.13.1",
-				"kleur": "^3.0.3",
-				"listify": "^1.0.0",
-				"lodash": "^4.17.15",
-				"minimist": "^1.2.0",
-				"prop-ini": "^0.0.2",
-				"readme-badger": "^0.3.0",
-				"semver": "^6.3.0",
-				"smpltmpl": "^1.0.2",
-				"split-lines": "^2.0.0",
-				"strip-bom": "^4.0.0",
-				"webpack-merge": "^4.2.2"
-			}
-		},
-		"mrm-preset-default": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.0.3.tgz",
-			"integrity": "sha512-V8A9s53x6ilssrmPhGyvtjmtS1jAXwG946gjY1liafXwiaAKPjQiI5VkAHt9nIrb9bIvG2WMpzJ0pkmREDZWsw==",
-			"requires": {
-				"mrm-core": "^4.0.0",
-				"mrm-task-codecov": "^2.0.2",
-				"mrm-task-contributing": "^2.0.3",
-				"mrm-task-editorconfig": "^2.0.2",
-				"mrm-task-eslint": "^2.0.2",
-				"mrm-task-gitignore": "^2.0.2",
-				"mrm-task-jest": "^2.0.2",
-				"mrm-task-license": "^3.0.1",
-				"mrm-task-lint-staged": "^3.0.1",
-				"mrm-task-package": "^2.0.2",
-				"mrm-task-prettier": "^2.0.2",
-				"mrm-task-readme": "^2.0.2",
-				"mrm-task-semantic-release": "^3.0.2",
-				"mrm-task-styleguidist": "^2.0.2",
-				"mrm-task-stylelint": "^3.0.2",
-				"mrm-task-travis": "^2.0.2",
-				"mrm-task-typescript": "^2.0.2"
-			}
-		},
-		"mrm-task-codecov": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-2.0.2.tgz",
-			"integrity": "sha512-fCqQmUZ7ywATy+MiibdhJDT+GKsRRmlcohEg1yKffM2CXgCJIRjKwOyNmfodPJTkdPl0IoqMs3IRpX4MXmAAdw==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-contributing": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.3.tgz",
-			"integrity": "sha512-hUohheTHeojJvK32tMRGelFlP/QOq0gJEYmzYWxhQOl/blKTTMRsPOknzBCo2PtHCMp15w9HnS+4WyPSNkIPyQ==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-editorconfig": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.2.tgz",
-			"integrity": "sha512-N2EfYpdNNy3XDLTdAk8ZG5EZprz/FkIqH4f3TZT9d2WiVg112kDptWj6lfvaAxzUFvXTxWqVFR+mHtt+ElwYLw==",
-			"requires": {
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-eslint": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.2.tgz",
-			"integrity": "sha512-lF+wRHp3auLGit1ypJbAUQAN2bFmqK3JhT5NTzkYD6LK/l3S+UZFKu4H9ez4YDfxUFWuRrgKC4oPk3M31ggPHA==",
-			"requires": {
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-gitignore": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.2.tgz",
-			"integrity": "sha512-04ylr3ywe+CtXvQrSGeNjznoRCcxBZ/pOUq6g57hzzhZS+Qx5yO+B3bfD7yGWeYXGHSI09rQZq5PhaQqcs3FOw==",
-			"requires": {
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-jest": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.2.tgz",
-			"integrity": "sha512-Lw4xMpAK4nhTDpRd5gow+YZrweqdQmEzxGAki2gj3lLhd4dSfYMT8E8P+uW5H+cH9c6iuzK7YfHmzKzcQdBfuA==",
-			"requires": {
-				"lodash": "^4.17.15",
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-license": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.0.1.tgz",
-			"integrity": "sha512-TPs/3uVCx/EAJtipRpHXC3DXH/AKH/8srovJu/2y0kfSluoDPv3voG2vnRCxrAq947PRbYouzr4Fe1a4R+kz4g==",
-			"requires": {
-				"mrm-core": "^4.0.0",
-				"user-meta": "^1.0.0"
-			}
-		},
-		"mrm-task-lint-staged": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.1.tgz",
-			"integrity": "sha512-NS3l+hZY4dntVQkse9njOCslCzPJYEXlruYxHriomwC/U3s9O2O5Lu1WMHEQzwaVIomTLaEd6kResA2fjxV/Nw==",
-			"requires": {
-				"lodash": "^4.17.15",
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-package": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.0.2.tgz",
-			"integrity": "sha512-dxseYF/8xuhtGWBUm11xiXtHL4sqeIe8erVWzp22FhRKhRlmxvlXT4vB4B18vdKKbtMf/DsxP1WDbtsjJPcsag==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.0.0",
-				"user-meta": "^1.0.0"
-			}
-		},
-		"mrm-task-prettier": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-2.0.2.tgz",
-			"integrity": "sha512-uZbTGjLvvpqoCqDn0A31R6Ll+LQBcauJheF+8qach7gU9GbZYT3NPefHP8pn24O3SZmkQmvOr5yGHlE7aeKunQ==",
-			"requires": {
-				"editorconfig-to-prettier": "0.1.1",
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-readme": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.0.2.tgz",
-			"integrity": "sha512-uYwlZirMaW1q1Gz/D/3y6ONv02EMwjQ+Wwp+KTphRBvFVluCtL2CKW/JBDZqP22NJBh71ZjdMMgAgCSL0zQtIA==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.0.0",
-				"user-meta": "^1.0.0"
-			}
-		},
-		"mrm-task-semantic-release": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-3.0.2.tgz",
-			"integrity": "sha512-FyD5hnybA1DAP+nQIQWZQErlOWdLJm5RDe+6zD4aRvE4YcT9gVTJMtd7RhP58XLGg5jAj5QuuQJFYXLqkbdGxw==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-styleguidist": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.2.tgz",
-			"integrity": "sha512-qpcuVich1S82UdXI/FULVaBfDwg1IIOYWtnxLVmU29bb7mgkkIEWix2MWYt4v0x/GszFo4YyxcpbFG+xHzj7jQ==",
-			"requires": {
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-stylelint": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.2.tgz",
-			"integrity": "sha512-tef0uuZuOWCsKfZojO6Z5cTrkI2FnoOtY4ThWW7KWK9AGMq72DBGZ1F877+2GwglpsAxZTA9WYpHMrVjWVceLw==",
-			"requires": {
-				"mrm-core": "^4.0.0"
-			}
-		},
-		"mrm-task-travis": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.0.2.tgz",
-			"integrity": "sha512-mf6Me0HDPvUMJJZnjlq5tuFP8+nHZjbIPVYKoT+UrOe6cq4sv6JAc0EI6i84n0AeRlnkfVxLaZiomyBLN6Uc0g==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"lodash": "^4.17.15",
-				"mrm-core": "^4.0.0",
-				"semver-utils": "^1.1.4"
-			}
-		},
-		"mrm-task-typescript": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.2.tgz",
-			"integrity": "sha512-c+Sog1jAjaUhFh1d+ImIldbNENkjoZQo3T9BveMjn2/YEu5oB+opq9fhgblfe/LCIiWVrQbtWZt9affH4PozgQ==",
-			"requires": {
-				"mrm-core": "^4.0.0"
-			}
-		},
 		"mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -1127,27 +748,6 @@
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
 			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
-		"p-limit": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-			"requires": {
-				"p-try": "^2.0.0"
-			}
-		},
-		"p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"requires": {
-				"p-limit": "^2.2.0"
-			}
-		},
-		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-		},
 		"package-json": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
@@ -1180,11 +780,6 @@
 			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
 			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
 		},
-		"path-exists": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1215,14 +810,6 @@
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
 			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
-		"prop-ini": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/prop-ini/-/prop-ini-0.0.2.tgz",
-			"integrity": "sha1-ZzOny1JCrKsr5C5gdYPYEksXKls=",
-			"requires": {
-				"extend": "^3.0.0"
-			}
-		},
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1246,14 +833,6 @@
 				"ini": "~1.3.0",
 				"minimist": "^1.2.0",
 				"strip-json-comments": "~2.0.1"
-			}
-		},
-		"readme-badger": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/readme-badger/-/readme-badger-0.3.0.tgz",
-			"integrity": "sha512-+sMOLSs1imZUISZ2Rhz7qqVd77QtpcAPbGeIraFdgJmijb04YtdlPjGNBvDChTNtLbeQ6JNGQy3pOgslWfaP3g==",
-			"requires": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"registry-auth-token": {
@@ -1280,11 +859,6 @@
 			"requires": {
 				"parse-git-config": "^1.1.1"
 			}
-		},
-		"repeat-string": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"requireg": {
 			"version": "0.2.2",
@@ -1385,33 +959,10 @@
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
-		"smpltmpl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/smpltmpl/-/smpltmpl-1.0.2.tgz",
-			"integrity": "sha512-Hq23NNgeZigOzIiX1dkb6W3gFn2/XQj43KhPxu65IMieG/gIwf/lQb1IudjYv0c/5LwJeS/mPayYzyo+8WJMxQ==",
-			"requires": {
-				"babel-code-frame": "^6.26.0"
-			}
-		},
-		"split-lines": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/split-lines/-/split-lines-2.0.0.tgz",
-			"integrity": "sha512-gaIdhbqxkB5/VflPXsJwZvEzh/kdwiRPF9iqpkxX4us+lzB8INedFwjCyo6vwuz5x2Ddlnav2zh270CEjCG8mA=="
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"string-width": {
 			"version": "3.1.0",
@@ -1452,11 +1003,6 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				}
 			}
-		},
-		"strip-bom": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -1533,11 +1079,6 @@
 				"crypto-random-string": "^1.0.0"
 			}
 		},
-		"universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-		},
 		"update-notifier": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-3.0.1.tgz",
@@ -1607,14 +1148,6 @@
 			"integrity": "sha512-Q/opMgFhVbBkdlTs44UKzV7L5Uj2zrJ4MVPXTTzJmrU1bHb2cX6wJzBIqEf1gROTzZIH8u39WmHsa5EvfnMPrw==",
 			"requires": {
 				"rc": "^1.2.1"
-			}
-		},
-		"webpack-merge": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
-			"integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
-			"requires": {
-				"lodash": "^4.17.15"
 			}
 		},
 		"which": {

--- a/packages/mrm/test/dir3/task6/index.js
+++ b/packages/mrm/test/dir3/task6/index.js
@@ -13,6 +13,13 @@ module.exports.parameters = {
 	'third-config': {
 		type: 'input',
 		message: 'Please, fulfil this third interactive input',
-		default: jest.fn(() => 'default value'),
+		default: jest.fn(
+			values =>
+				values['second-config'] &&
+				values['second-config']
+					.split('')
+					.reverse()
+					.join('')
+		),
 	},
 };

--- a/packages/mrm/test/dir5/task8/index.js
+++ b/packages/mrm/test/dir5/task8/index.js
@@ -1,0 +1,13 @@
+module.exports = jest.fn();
+module.exports.description = 'Taks 5.8';
+module.exports.parameters = {
+	'interactive-config': {
+		type: 'input',
+		message: 'Please, fulfil this first interactive input',
+		validate: value => (value === 'pizza' ? true : 'Invalid!'),
+	},
+	'static-config': {
+		type: 'config',
+		default: 'default value',
+	},
+};


### PR DESCRIPTION
- [x] New config API (the old API still works but deprecated)
- [x] Support config only options (`type: 'static'`)
- [x] Validation works in non-interactive mode
- [x] Defaults work consistently in interactive and non-interactive modes

## New config API

Tasks now receive an object with resolved values (merged config, command line and interactive values). Defaults, validations and interactive prompts are defined via `parameters` object. See docs for more details.

## Deprecations

`values()`, `require()` and `defaults()` methods on config object are deprecated and will be removed in the next major release.