### PR TITLE
fix(eslint): add prettier rules if installed without TS

### DIFF
--- a/packages/mrm-task-eslint/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-eslint/__snapshots__/index.spec.js.snap
@@ -212,6 +212,29 @@ Object {
 }
 `;
 
+exports[`should turn on Prettier-specific eslint rules when prettier is installed 1`] = `
+Object {
+  "/.eslintignore": "node_modules/",
+  "/.eslintrc.json": "{
+  \\"extends\\": [
+    \\"eslint:recommended\\",
+    \\"prettier\\"
+  ]
+}",
+  "/.gitignore": ".eslintcache",
+  "/package.json": "{
+  \\"name\\": \\"unicorn\\",
+  \\"devDependencies\\": {
+    \\"prettier\\": \\"*\\"
+  },
+  \\"scripts\\": {
+    \\"lint\\": \\"eslint . --cache --fix\\",
+    \\"pretest\\": \\"npm run lint\\"
+  }
+}",
+}
+`;
+
 exports[`should use a custom preset 1`] = `
 "{
   \\"extends\\": \\"airbnb\\"

--- a/packages/mrm-task-eslint/index.js
+++ b/packages/mrm-task-eslint/index.js
@@ -74,7 +74,8 @@ function task(config) {
 	// }
 
 	// TypeScript
-	if (pkg.get('devDependencies.typescript')) {
+	const hasTypescript = pkg.get('devDependencies.typescript');
+	if (hasTypescript) {
 		const parser = '@typescript-eslint/parser';
 		const plugin = '@typescript-eslint/eslint-plugin';
 		packages.push(parser, plugin);
@@ -93,18 +94,19 @@ function task(config) {
 			rules: eslintRules || {},
 		});
 		exts = ' --ext .ts,.tsx';
+	}
 
-		if (pkg.get('devDependencies.prettier')) {
-			packages.push('eslint-config-prettier');
-			const extensions = eslintrc.get('extends', []);
-			eslintrc.merge({
-				extends: [
-					...(Array.isArray(extensions) ? extensions : [extensions]),
-					'prettier',
-					'prettier/@typescript-eslint',
-				],
-			});
-		}
+	// Prettier
+	if (pkg.get('devDependencies.prettier')) {
+		packages.push('eslint-config-prettier');
+		const extensions = eslintrc.get('extends', []);
+		eslintrc.merge({
+			extends: [
+				...(Array.isArray(extensions) ? extensions : [extensions]),
+				'prettier',
+				...(hasTypescript ? ['prettier/@typescript-eslint'] : []),
+			],
+		});
 	}
 
 	eslintrc.save();

--- a/packages/mrm-task-eslint/index.spec.js
+++ b/packages/mrm-task-eslint/index.spec.js
@@ -240,6 +240,21 @@ it('should turn off TypeScript-specific eslint rules that conflict with Prettier
 	expect(vol.toJSON()).toMatchSnapshot();
 });
 
+it('should turn on Prettier-specific eslint rules when prettier is installed', () => {
+	vol.fromJSON({
+		'/package.json': stringify({
+			name: 'unicorn',
+			devDependencies: {
+				prettier: '*',
+			},
+		}),
+	});
+
+	task(getConfigGetter({}));
+
+	expect(vol.toJSON()).toMatchSnapshot();
+});
+
 it('should migrate legacy config file', () => {
 	vol.fromJSON({
 		'/package.json': packageJson,


### PR DESCRIPTION
## The problem

Currently, the task will only add the prettier rules if Typescript is also
installed.

## What was changed

- [x] add `eslint-config-prettier` if prettier is installed, regardless of TS