### PR TITLE
feat: resolve scoped presets and tasks

### DIFF
--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -79,12 +79,12 @@ const isDefaultPreset = preset === 'default';
 if (isDefaultPreset) {
 	directories.push(path.dirname(require.resolve('mrm-preset-default')));
 } else {
-	const resolvablePreset = getPackageName('preset', preset);
-	const presetPath = tryResolve(resolvablePreset, preset);
+	const presetPackageName = getPackageName('preset', preset);
+	const presetPath = tryResolve(presetPackageName, preset);
 	if (!presetPath) {
 		printError(`Preset “${preset}” not found.
 
-We’ve tried to load “${resolvablePreset}” and “${preset}” globally installed npm packages.`);
+We’ve tried to load “${presetPackageName}” and “${preset}” globally installed npm packages.`);
 		process.exit(1);
 	}
 	directories = [path.dirname(presetPath)];

--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -16,7 +16,7 @@ const {
 	getConfig,
 	getAllTasks,
 	tryResolve,
-	getResolvableName,
+	getPackageName,
 } = require('../src/index');
 const {
 	MrmUnknownTask,
@@ -79,7 +79,7 @@ const isDefaultPreset = preset === 'default';
 if (isDefaultPreset) {
 	directories.push(path.dirname(require.resolve('mrm-preset-default')));
 } else {
-	const resolvablePreset = getResolvableName('preset', preset);
+	const resolvablePreset = getPackageName('preset', preset);
 	const presetPath = tryResolve(resolvablePreset, preset);
 	if (!presetPath) {
 		printError(`Preset “${preset}” not found.

--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -11,7 +11,13 @@ const listify = require('listify');
 const updateNotifier = require('update-notifier');
 const { padEnd, sortBy } = require('lodash');
 const { random } = require('middleearth-names');
-const { run, getConfig, getAllTasks, tryResolve } = require('../src/index');
+const {
+	run,
+	getConfig,
+	getAllTasks,
+	tryResolve,
+	getResolvableName,
+} = require('../src/index');
 const {
 	MrmUnknownTask,
 	MrmInvalidTask,
@@ -73,11 +79,12 @@ const isDefaultPreset = preset === 'default';
 if (isDefaultPreset) {
 	directories.push(path.dirname(require.resolve('mrm-preset-default')));
 } else {
-	const presetPath = tryResolve(`mrm-preset-${preset}`, preset);
+	const resolvablePreset = getResolvableName('preset', preset);
+	const presetPath = tryResolve(resolvablePreset, preset);
 	if (!presetPath) {
 		printError(`Preset “${preset}” not found.
 
-We’ve tried to load “mrm-preset-${preset}” and “${preset}” globally installed npm packages.`);
+We’ve tried to load “${resolvablePreset}” and “${preset}” globally installed npm packages.`);
 		process.exit(1);
 	}
 	directories = [path.dirname(presetPath)];

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -16,6 +16,7 @@ const {
 	run,
 	getAllAliases,
 	getAllTasks,
+	getResolvableName,
 } = require('../index');
 const configureInquirer = require('../../test/inquirer-mock');
 const task1 = require('../../test/dir1/task1');
@@ -102,6 +103,25 @@ describe('tryResolve', () => {
 	it('should not throw when undefined was passed instead of a module name', () => {
 		const fn = () => tryResolve(undefined);
 		expect(fn).not.toThrowError();
+	});
+});
+
+describe('getResolvableName', () => {
+	it('should resolve non-scoped task names', () => {
+		const result = getResolvableName('task', 'pizza');
+		expect(result).toEqual('mrm-task-pizza');
+	});
+	it('should resolve non-scoped preset names', () => {
+		const result = getResolvableName('preset', 'default');
+		expect(result).toEqual('mrm-preset-default');
+	});
+	it('should resolve scoped task names', () => {
+		const result = getResolvableName('task', '@myorg/pizza');
+		expect(result).toEqual('@myorg/mrm-task-pizza');
+	});
+	it('should resolve scoped preset names', () => {
+		const result = getResolvableName('preset', '@myorg/default');
+		expect(result).toEqual('@myorg/mrm-preset-default');
 	});
 });
 

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -16,7 +16,7 @@ const {
 	run,
 	getAllAliases,
 	getAllTasks,
-	getResolvableName,
+	getPackageName,
 } = require('../index');
 const configureInquirer = require('../../test/inquirer-mock');
 const task1 = require('../../test/dir1/task1');
@@ -106,21 +106,21 @@ describe('tryResolve', () => {
 	});
 });
 
-describe('getResolvableName', () => {
+describe('getPackageName', () => {
 	it('should resolve non-scoped task names', () => {
-		const result = getResolvableName('task', 'pizza');
+		const result = getPackageName('task', 'pizza');
 		expect(result).toEqual('mrm-task-pizza');
 	});
 	it('should resolve non-scoped preset names', () => {
-		const result = getResolvableName('preset', 'default');
+		const result = getPackageName('preset', 'default');
 		expect(result).toEqual('mrm-preset-default');
 	});
 	it('should resolve scoped task names', () => {
-		const result = getResolvableName('task', '@myorg/pizza');
+		const result = getPackageName('task', '@myorg/pizza');
 		expect(result).toEqual('@myorg/mrm-task-pizza');
 	});
 	it('should resolve scoped preset names', () => {
-		const result = getResolvableName('preset', '@myorg/default');
+		const result = getPackageName('preset', '@myorg/default');
 		expect(result).toEqual('@myorg/mrm-preset-default');
 	});
 });

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -120,7 +120,7 @@ function runAlias(aliasName, directories, options, argv) {
  * @param {string} packageName
  * @returns {string}
  */
-function getResolvableName(type, packageName) {
+function getPackageName(type, packageName) {
 	const [scopeOrTask, scopedTaskName] = packageName.split('/');
 	return scopedTaskName
 		? `${scopeOrTask}/mrm-${type}-${scopedTaskName}`
@@ -138,7 +138,7 @@ function getResolvableName(type, packageName) {
  */
 function runTask(taskName, directories, options, argv) {
 	return new Promise((resolve, reject) => {
-		const resolvableTaskName = getResolvableName('task', taskName);
+		const resolvableTaskName = getPackageName('task', taskName);
 		const modulePath = tryResolve(
 			tryFile(directories, `${taskName}/index.js`),
 			resolvableTaskName,
@@ -402,6 +402,6 @@ module.exports = {
 	getTaskOptions,
 	tryFile,
 	tryResolve,
-	getResolvableName,
+	getPackageName,
 	firstResult,
 };

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -138,10 +138,10 @@ function getPackageName(type, packageName) {
  */
 function runTask(taskName, directories, options, argv) {
 	return new Promise((resolve, reject) => {
-		const resolvableTaskName = getPackageName('task', taskName);
+		const taskPackageName = getPackageName('task', taskName);
 		const modulePath = tryResolve(
 			tryFile(directories, `${taskName}/index.js`),
-			resolvableTaskName,
+			taskPackageName,
 			taskName
 		);
 

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -114,6 +114,20 @@ function runAlias(aliasName, directories, options, argv) {
 }
 
 /**
+ * Returns the correct `mrm-` prefixed package name
+ *
+ * @param {"task" | "preset"} type
+ * @param {string} packageName
+ * @returns {string}
+ */
+function getResolvableName(type, packageName) {
+	const [scopeOrTask, scopedTaskName] = packageName.split('/');
+	return scopedTaskName
+		? `${scopeOrTask}/mrm-${type}-${scopedTaskName}`
+		: `mrm-${type}-${scopeOrTask}`;
+}
+
+/**
  * Run a task.
  *
  * @param {string} taskName
@@ -124,14 +138,19 @@ function runAlias(aliasName, directories, options, argv) {
  */
 function runTask(taskName, directories, options, argv) {
 	return new Promise((resolve, reject) => {
+		const resolvableTaskName = getResolvableName('task', taskName);
 		const modulePath = tryResolve(
 			tryFile(directories, `${taskName}/index.js`),
-			`mrm-task-${taskName}`,
+			resolvableTaskName,
 			taskName
 		);
 
 		if (!modulePath) {
-			reject(new MrmUnknownTask(`Task “${taskName}” not found.`, { taskName }));
+			reject(
+				new MrmUnknownTask(`Task “${taskName}” not found.`, {
+					taskName,
+				})
+			);
 			return;
 		}
 
@@ -383,5 +402,6 @@ module.exports = {
 	getTaskOptions,
 	tryFile,
 	tryResolve,
+	getResolvableName,
 	firstResult,
 };


### PR DESCRIPTION
Closes #75

| Before the changes | After the changes |
| - | - | 
| ![image](https://user-images.githubusercontent.com/48519/80160801-cef2d780-85ce-11ea-8623-fb257d04c4ac.png) | ![image](https://user-images.githubusercontent.com/48519/80160587-483dfa80-85ce-11ea-8929-43ca09611039.png) |

The idea was to make sure packages like `@myorg/default` would try to be resolved as both `@myorg/mrm-preset-default` and `@myorg/default`, so even if you pass `@myorg/mrm-preset-default` it will still resolve.

There are no breaking changes introduced, all tests are passing.

I wasn't sure about the `package-lock.json` files, so I didn't commit them since I didn't change anhy of the dependencies.

Let me know if anything needs to be changed.

Cheers