### PR TITLE
Add missing set function signature for JSON to mrm-core types

### DIFF
--- a/packages/mrm-core/types/index.d.ts
+++ b/packages/mrm-core/types/index.d.ts
@@ -22,6 +22,7 @@ interface Json {
 	get(): any
 	get(address: string | string[], defaultValue?: any): any;
 	set(address: string | string[], value: any): this;
+	set(value: any): this;
 	unset(address: string | string[]): this;
 	merge(value: object): this;
 	save(): this;


### PR DESCRIPTION
Json's `.set()` can be called with one or two parameters, but the current `mrm-core` types do not reflect this.

This PR updates the `Json` type interface to include this usage pattern. 