### PR TITLE
fix: Handle non-registry installs

### DIFF
--- a/packages/mrm-core/Readme.md
+++ b/packages/mrm-core/Readme.md
@@ -320,6 +320,7 @@ install({ lodash: '^4.17.3' }); // Install particular version
 install(['lodash'], {
   versions: { lodash: '^4.17.3', other: '1.0.0' }
 }); // Install particular version
+install(['github/repo']); // Install non-registry package without version
 ```
 
 **Note:** Works with all [semver](https://semver.org/) ranges, like `1.2.3`, `^1.2.0` or `>=2`.

--- a/packages/mrm-core/package-lock.json
+++ b/packages/mrm-core/package-lock.json
@@ -56,6 +56,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "builtins": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
+      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+    },
     "commander": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
@@ -315,6 +320,14 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
+      "requires": {
+        "builtins": "^1.0.3"
+      }
     },
     "webpack-merge": {
       "version": "4.2.2",

--- a/packages/mrm-core/package.json
+++ b/packages/mrm-core/package.json
@@ -36,6 +36,7 @@
     "smpltmpl": "^1.0.2",
     "split-lines": "^2.0.0",
     "strip-bom": "^4.0.0",
+    "validate-npm-package-name": "^3.0.0",
     "webpack-merge": "^4.2.2"
   },
   "keywords": [

--- a/packages/mrm-core/src/__tests__/npm.spec.js
+++ b/packages/mrm-core/src/__tests__/npm.spec.js
@@ -230,15 +230,15 @@ describe('install()', () => {
 		const fn = () => install({ eslint: '~4.2.0' }, undefined, spawn);
 		expect(fn).not.toThrow('Invalid npm version');
 	});
-
-	it('should not automatically add version data to non-registry installs', () => {
-		[
-			'github/package',
-			'https://github.com/user/package/tarball/v0.0.1',
-			'github:mygithubuser/myproject',
-			'gist:101a11beef',
-			'bitbucket:mybitbucketuser/myproject',
-		].forEach(resource => {
+	it.each([
+		['github', 'github/package'],
+		['github https', 'https://github.com/user/package/tarball/v0.0.1'],
+		['github protocol', 'github:mygithubuser/myproject'],
+		['gist', 'gist:101a11beef'],
+		['bitbucket protocol', 'bitbucket:mybitbucketuser/myproject'],
+	])(
+		'should not automatically add version data to non-registry installs: %s',
+		(name, resource) => {
 			const spawn = jest.fn();
 			install([resource], undefined, spawn);
 			expect(spawn).toBeCalledWith(
@@ -246,17 +246,21 @@ describe('install()', () => {
 				['install', '--save-dev', resource],
 				options
 			);
-		});
-	});
-
-	it('should add semver tags to non-registry installs if provided', () => {
+		}
+	);
+	it.each([
+		['github', 'github/package', '1.0.0'],
 		[
-			['github/package', '1.0.0'],
-			['https://github.com/user/package/tarball/v0.0.1', '>=2.0.0'],
-			['github:mygithubuser/myproject', '>3.0.0'],
-			['gist:101a11beef', '4.0.0'],
-			['bitbucket:mybitbucketuser/myproject', '5.0.0'],
-		].forEach(([resource, version]) => {
+			'github https',
+			'https://github.com/user/package/tarball/v0.0.1',
+			'>=2.0.0',
+		],
+		['github protocol', 'github:mygithubuser/myproject', '>3.0.0'],
+		['gist', 'gist:101a11beef', '4.0.0'],
+		['bitbucket protocol', 'bitbucket:mybitbucketuser/myproject', '5.0.0'],
+	])(
+		'should not automatically add version data to non-registry installs: %s',
+		(name, resource, version) => {
 			const spawn = jest.fn();
 			const matcher = new RegExp(`^${resource}#semver:${version}$`);
 			install({ [resource]: version }, undefined, spawn);
@@ -265,8 +269,8 @@ describe('install()', () => {
 				['install', '--save-dev', expect.stringMatching(matcher)],
 				options
 			);
-		});
-	});
+		}
+	);
 
 	it('should not throw when package.json not found', () => {
 		const spawn = jest.fn();


### PR DESCRIPTION
This change addresses #89 

- Fixes handling of non-registry packages by omitting version information by default.
- When a non-registry package is given an explicit version, uses the `#semver:<semver>` syntax, as supported by NPM and Yarn (https://docs.npmjs.com/cli/install)
- Adds tests for the above.