### PR TITLE
feat: automatic global install for tasks and presets

### DIFF
--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -48,16 +48,16 @@ const EXAMPLES = [
 const pkg = require('../package.json');
 updateNotifier({ pkg }).notify();
 
-async function main() {
-	process.on('unhandledRejection', err => {
-		if (err.constructor.name === 'MrmError') {
-			printError(err.message);
-			process.exit(1);
-		} else {
-			throw err;
-		}
-	});
+process.on('unhandledRejection', err => {
+	if (err.constructor.name === 'MrmError') {
+		printError(err.message);
+		process.exit(1);
+	} else {
+		throw err;
+	}
+});
 
+async function main() {
 	const argv = minimist(process.argv.slice(2), { alias: { i: 'interactive' } });
 	const tasks = argv._;
 
@@ -162,7 +162,7 @@ Note that when a preset is specified no default search locations are used.`
 		}
 
 		if (isDefaultPreset) {
-			return paths.concat(path.dirname(require.resolve('mrm-preset-default')));
+			return [...paths, path.dirname(require.resolve('mrm-preset-default'))];
 		}
 
 		const presetPackageName = getPackageName('preset', preset);
@@ -230,12 +230,12 @@ We’ve tried to load “${presetPackageName}” and “${preset}” globally in
 			})
 			.join('\n');
 	}
+}
 
-	function printError(message) {
-		console.log();
-		console.error(kleur.bold().red(message));
-		console.log();
-	}
+function printError(message) {
+	console.log();
+	console.error(kleur.bold().red(message));
+	console.log();
 }
 
 main();

--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -186,13 +186,13 @@ Note that when a preset is specified no default search locations are used.`
 	function getUsage() {
 		const commands = EXAMPLES.map(x => x[0] + x[1]);
 		const commandsWidth = longest(commands).length;
-		return EXAMPLES.map(([command, options, description]) =>
+		return EXAMPLES.map(([command, opts, description]) =>
 			[
 				'   ',
 				kleur.bold(binaryName),
 				kleur.cyan(command),
-				kleur.yellow(options),
-				padEnd('', commandsWidth - (command + options).length),
+				kleur.yellow(opts),
+				padEnd('', commandsWidth - (command + opts).length),
 				description && `# ${description}`,
 			].join(' ')
 		).join('\n');

--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -46,97 +46,99 @@ const EXAMPLES = [
 const pkg = require('../package.json');
 updateNotifier({ pkg }).notify();
 
-process.on('unhandledRejection', err => {
-	if (err.constructor.name === 'MrmError') {
-		printError(err.message);
-		process.exit(1);
+async function main() {
+	process.on('unhandledRejection', err => {
+		if (err.constructor.name === 'MrmError') {
+			printError(err.message);
+			process.exit(1);
+		} else {
+			throw err;
+		}
+	});
+
+	const argv = minimist(process.argv.slice(2), { alias: { i: 'interactive' } });
+	const tasks = argv._;
+
+	const binaryPath = process.env._;
+	const binaryName =
+		binaryPath && binaryPath.endsWith('/npx') ? 'npx mrm' : 'mrm';
+
+	// Custom config / tasks directory
+	if (argv.dir) {
+		const dir = path.resolve(argv.dir);
+		if (!isDirectory.sync(dir)) {
+			printError(`Directory “${dir}” not found.`);
+			process.exit(1);
+		}
+
+		directories.unshift(dir);
+	}
+
+	// Preset
+	const preset = argv.preset || 'default';
+	const isDefaultPreset = preset === 'default';
+	if (isDefaultPreset) {
+		directories.push(path.dirname(require.resolve('mrm-preset-default')));
 	} else {
-		throw err;
-	}
-});
-
-const argv = minimist(process.argv.slice(2), { alias: { i: 'interactive' } });
-const tasks = argv._;
-
-const binaryPath = process.env._;
-const binaryName =
-	binaryPath && binaryPath.endsWith('/npx') ? 'npx mrm' : 'mrm';
-
-// Custom config / tasks directory
-if (argv.dir) {
-	const dir = path.resolve(argv.dir);
-	if (!isDirectory.sync(dir)) {
-		printError(`Directory “${dir}” not found.`);
-		process.exit(1);
-	}
-
-	directories.unshift(dir);
-}
-
-// Preset
-const preset = argv.preset || 'default';
-const isDefaultPreset = preset === 'default';
-if (isDefaultPreset) {
-	directories.push(path.dirname(require.resolve('mrm-preset-default')));
-} else {
-	const presetPackageName = getPackageName('preset', preset);
-	const presetPath = tryResolve(presetPackageName, preset);
-	if (!presetPath) {
-		printError(`Preset “${preset}” not found.
+		const presetPackageName = getPackageName('preset', preset);
+		const presetPath = await tryResolve(presetPackageName, preset);
+		if (!presetPath) {
+			printError(`Preset “${preset}” not found.
 
 We’ve tried to load “${presetPackageName}” and “${preset}” globally installed npm packages.`);
-		process.exit(1);
+			process.exit(1);
+		}
+		// eslint-disable-next-line require-atomic-updates
+		directories = [path.dirname(presetPath)];
 	}
-	directories = [path.dirname(presetPath)];
-}
 
-const options = getConfig(directories, 'config.json', argv);
-if (tasks.length === 0 || tasks[0] === 'help') {
-	commandHelp();
-} else {
-	run(tasks, directories, options, argv).catch(err => {
-		if (err.constructor === MrmUnknownAlias) {
-			printError(err.message);
-		} else if (err.constructor === MrmUnknownTask) {
-			const { taskName } = err.extra;
-			if (isDefaultPreset) {
-				const modules = directories
-					.slice(0, -1)
-					.map(d => `${d}/${taskName}/index.js`)
-					.concat([
-						`“${taskName}” in the default mrm tasks`,
-						`npm install -g mrm-task-${taskName}`,
-						`npm install -g ${taskName}`,
-					]);
-				printError(
-					`${err.message}
+	const options = getConfig(directories, 'config.json', argv);
+	if (tasks.length === 0 || tasks[0] === 'help') {
+		commandHelp();
+	} else {
+		run(tasks, directories, options, argv).catch(err => {
+			if (err.constructor === MrmUnknownAlias) {
+				printError(err.message);
+			} else if (err.constructor === MrmUnknownTask) {
+				const { taskName } = err.extra;
+				if (isDefaultPreset) {
+					const modules = directories
+						.slice(0, -1)
+						.map(d => `${d}/${taskName}/index.js`)
+						.concat([
+							`“${taskName}” in the default mrm tasks`,
+							`npm install -g mrm-task-${taskName}`,
+							`npm install -g ${taskName}`,
+						]);
+					printError(
+						`${err.message}
 
 We’ve tried these locations:
 
 - ${modules.join('\n- ')}`
-				);
-			} else {
-				printError(`Task “${taskName}” not found in the “${preset}” preset.
+					);
+				} else {
+					printError(`Task “${taskName}” not found in the “${preset}” preset.
 
 Note that when a preset is specified no default search locations are used.`);
-			}
-		} else if (err.constructor === MrmInvalidTask) {
-			printError(`${err.message}
+				}
+			} else if (err.constructor === MrmInvalidTask) {
+				printError(`${err.message}
 
 Make sure your task module exports a function.`);
-		} else if (err.constructor === MrmUndefinedOption) {
-			const { unknown } = err.extra;
-			const values = unknown.map(name => [name, random()]);
-			const heading = `Required config options are missed: ${listify(
-				unknown
-			)}.`;
-			const cliHelp = `  ${binaryName} ${tasks.join(' ')} ${values
-				.map(([n, v]) => `--config:${n} "${v}"`)
-				.join(' ')}`;
-			if (isDefaultPreset) {
-				const userDirectories = directories.slice(0, -1);
-				printError(
-					`${heading}
+			} else if (err.constructor === MrmUndefinedOption) {
+				const { unknown } = err.extra;
+				const values = unknown.map(name => [name, random()]);
+				const heading = `Required config options are missed: ${listify(
+					unknown
+				)}.`;
+				const cliHelp = `  ${binaryName} ${tasks.join(' ')} ${values
+					.map(([n, v]) => `--config:${n} "${v}"`)
+					.join(' ')}`;
+				if (isDefaultPreset) {
+					const userDirectories = directories.slice(0, -1);
+					printError(
+						`${heading}
 
 1. Create a “config.json” file:
 
@@ -152,69 +154,72 @@ In one of these folders:
 
 ${cliHelp}
 	`
-				);
-			} else {
-				printError(
-					`${heading}
+					);
+				} else {
+					printError(
+						`${heading}
 
 You can pass the option via command line:
 
 ${cliHelp}
 
 Note that when a preset is specified no default search locations are used.`
-				);
+					);
+				}
+			} else {
+				throw err;
 			}
-		} else {
-			throw err;
-		}
-	});
+		});
+	}
+
+	function commandHelp() {
+		console.log(
+			[
+				kleur.underline('Usage'),
+				getUsage(),
+				kleur.underline('Available tasks'),
+				getTasksList(options),
+			].join('\n\n')
+		);
+	}
+
+	function getUsage() {
+		const commands = EXAMPLES.map(x => x[0] + x[1]);
+		const commandsWidth = longest(commands).length;
+		return EXAMPLES.map(([command, options, description]) =>
+			[
+				'   ',
+				kleur.bold(binaryName),
+				kleur.cyan(command),
+				kleur.yellow(options),
+				padEnd('', commandsWidth - (command + options).length),
+				description && `# ${description}`,
+			].join(' ')
+		).join('\n');
+	}
+
+	function getTasksList() {
+		const allTasks = getAllTasks(directories, options);
+		const names = sortBy(Object.keys(allTasks));
+		const nameColWidth = longest(names).length;
+
+		return names
+			.map(name => {
+				const description = Array.isArray(allTasks[name])
+					? `Runs ${listify(allTasks[name])}`
+					: allTasks[name];
+				return (
+					'    ' + kleur.cyan(padEnd(name, nameColWidth)) + '  ' + description
+				);
+			})
+			.join('\n');
+	}
+
+	function printError(message) {
+		console.log();
+		console.error(kleur.bold().red(message));
+		console.log();
+	}
 }
 
-function commandHelp() {
-	console.log(
-		[
-			kleur.underline('Usage'),
-			getUsage(),
-			kleur.underline('Available tasks'),
-			getTasksList(options),
-		].join('\n\n')
-	);
-}
-
-function getUsage() {
-	const commands = EXAMPLES.map(x => x[0] + x[1]);
-	const commandsWidth = longest(commands).length;
-	return EXAMPLES.map(([command, options, description]) =>
-		[
-			'   ',
-			kleur.bold(binaryName),
-			kleur.cyan(command),
-			kleur.yellow(options),
-			padEnd('', commandsWidth - (command + options).length),
-			description && `# ${description}`,
-		].join(' ')
-	).join('\n');
-}
-
-function getTasksList() {
-	const allTasks = getAllTasks(directories, options);
-	const names = sortBy(Object.keys(allTasks));
-	const nameColWidth = longest(names).length;
-
-	return names
-		.map(name => {
-			const description = Array.isArray(allTasks[name])
-				? `Runs ${listify(allTasks[name])}`
-				: allTasks[name];
-			return (
-				'    ' + kleur.cyan(padEnd(name, nameColWidth)) + '  ' + description
-			);
-		})
-		.join('\n');
-}
-
-function printError(message) {
-	console.log();
-	console.error(kleur.bold().red(message));
-	console.log();
-}
+main();

--- a/packages/mrm/package-lock.json
+++ b/packages/mrm/package-lock.json
@@ -220,9 +220,9 @@
 			},
 			"dependencies": {
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -337,6 +337,16 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
+		"cross-spawn": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
 		"crypto-random-string": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -395,11 +405,6 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
-		},
-		"editorconfig-to-prettier": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz",
-			"integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ=="
 		},
 		"emoji-regex": {
 			"version": "7.0.3",
@@ -759,6 +764,11 @@
 			"resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
 			"integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw=="
 		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
 		"js-tokens": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -909,173 +919,6 @@
 				"webpack-merge": "^4.2.2"
 			}
 		},
-		"mrm-preset-default": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.1.0.tgz",
-			"integrity": "sha512-IbAOF4IHgaLzQwttKfxjy89VWlaKqYFPa0DdplmrvyW70d5/Ulglf8ikWqZStk8EI0Ld69L/KU9HfKNDwvZYvw==",
-			"requires": {
-				"mrm-core": "^4.1.2",
-				"mrm-task-codecov": "^2.0.6",
-				"mrm-task-contributing": "^2.0.8",
-				"mrm-task-editorconfig": "^2.0.7",
-				"mrm-task-eslint": "^2.0.7",
-				"mrm-task-gitignore": "^2.0.7",
-				"mrm-task-jest": "^2.0.6",
-				"mrm-task-license": "^3.0.5",
-				"mrm-task-lint-staged": "^3.0.6",
-				"mrm-task-package": "^2.1.0",
-				"mrm-task-prettier": "^3.0.4",
-				"mrm-task-readme": "^2.0.6",
-				"mrm-task-semantic-release": "^3.0.7",
-				"mrm-task-styleguidist": "^2.0.6",
-				"mrm-task-stylelint": "^3.0.6",
-				"mrm-task-travis": "^2.0.6",
-				"mrm-task-typescript": "^2.0.6"
-			}
-		},
-		"mrm-task-codecov": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-2.0.6.tgz",
-			"integrity": "sha512-6iIgYO15iuEsDHaxpY5293m03DyNIFFC00BDCNBlESkP99Nq4IVzV5syzAwgRNZT6Kuqcw5BlR6wbZ8u9mV1lQ==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-contributing": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.8.tgz",
-			"integrity": "sha512-fP10Ys66xWONc0BPjRPEBNhHLzCpirPlafb/BurowvHctRNKl9fEZm4hjB2jjDO7xYkAg1kTXJlgUoG58Xq6tA==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-editorconfig": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.7.tgz",
-			"integrity": "sha512-agWtdg0paCVLu+fAuy3PJ/mfBg9jqrnQw/9GGGhnxeipYUige2OckSo0epc9sZy4Ex7zDWvzIuxL7UDeyQz9KQ==",
-			"requires": {
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-eslint": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.7.tgz",
-			"integrity": "sha512-4i/UBgfHx6X6xX6RcM46eMmwIA/uKSG0tk5xM2+a1WN9I8yUDn37QmDtM8qxITnFqq1ePzf3caYBUpBcXu2bpw==",
-			"requires": {
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-gitignore": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.7.tgz",
-			"integrity": "sha512-Jrk8xEs9GuvYgxYIC5xosUG/CfsFbYaw9qA3zyCSFXSsHe2STeUhU0NAN1yrEHneDlp0hv5B5ZCzLzlWw5Z1aw==",
-			"requires": {
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-jest": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.6.tgz",
-			"integrity": "sha512-kkUQ9KO/s+WXGOTklrJkhx0ltdicn1iczO7SG3QTm1ibhtSHsuoUi1fI8pVzE6B0nJQY8sGCs6+4Ir599LO/Xg==",
-			"requires": {
-				"lodash": "^4.17.15",
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-license": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.0.5.tgz",
-			"integrity": "sha512-YaUnlPDOcJo5w/8l+KNC0JgOxwG7hUxfKjZNewkq2z4cf7DInO7Xe/fl85xbvW3ufruaYD759G/9otYHQ2/xiA==",
-			"requires": {
-				"mrm-core": "^4.1.2",
-				"user-meta": "^1.0.0"
-			}
-		},
-		"mrm-task-lint-staged": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.6.tgz",
-			"integrity": "sha512-u45ncGSmcHn6kYE+t00dUGgLPH6ChR5CGWgW7stxo1oA38BF4DvTydk3XDdcQ69evIutigHu4+fEtHX3HyaMnw==",
-			"requires": {
-				"lodash": "^4.17.15",
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-package": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.0.tgz",
-			"integrity": "sha512-vj78mMgP3ZzJuKkBBeXYH99W/gqApAUMpMHaGnbu/DjrAXCf6SAcIbpkplGAUND22Puh4tk4YI3yZBJxikV/8g==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.1.2",
-				"user-meta": "^1.0.0"
-			}
-		},
-		"mrm-task-prettier": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.0.4.tgz",
-			"integrity": "sha512-q0BL4Fp6qVdqvf1E2oaDFlVoL6jJnSrysDTVjzA778KJWEQCqx0DMt4i9gnPxy2Lmsmri8FHcem5W1aRVHNo5g==",
-			"requires": {
-				"editorconfig-to-prettier": "0.1.1",
-				"lodash": "^4.17.15",
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-readme": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.0.6.tgz",
-			"integrity": "sha512-V2C+R/poQz24Cgccu3ySEd2bMdh1gUmHvennqPIQfPrVeCE+X3r0+dk3JsiuyPWPiUlMWe75K9tRt+xsHeMvRw==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.1.2",
-				"user-meta": "^1.0.0"
-			}
-		},
-		"mrm-task-semantic-release": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-3.0.7.tgz",
-			"integrity": "sha512-DK2vb8h29JYQVUKGamXDRlpnmdD0Ztga953eT5rdouGuZfnOrKrMFYYLXQxlIpDW8m67YeBnWuxt8lpu9yDBfg==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-styleguidist": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.6.tgz",
-			"integrity": "sha512-HCOFawbk0iCGPlKDbjjajbS4N8VNrKd6sEcqT1+j5FCEKE7Zkj+ga3gIo+LRls/E2pA+zWmpgDWwSPaJAL71+A==",
-			"requires": {
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-stylelint": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.6.tgz",
-			"integrity": "sha512-oYsUj7ZJOaQUDxmgiAvp3esKIPeb/a9XdYT7pbCZZdAD8TeTmNWL5546o2kvx1SwwNeKcpt63kXpMaodMuNQNQ==",
-			"requires": {
-				"mrm-core": "^4.1.2"
-			}
-		},
-		"mrm-task-travis": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.0.6.tgz",
-			"integrity": "sha512-fqOj72XIiyUSADvxVKQsUtkqdaBdhqWbYbqN5iUgO4GJ2tIFeuFiOmmKwbGI/tVmvZvCt9GBI25MkMRC+5gDiQ==",
-			"requires": {
-				"git-username": "^1.0.0",
-				"lodash": "^4.17.15",
-				"mrm-core": "^4.1.2",
-				"semver-utils": "^1.1.4"
-			}
-		},
-		"mrm-task-typescript": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.6.tgz",
-			"integrity": "sha512-l4juf9+vpjVReErYsphj5vQn+3EHyHmyTBNVs4a/Rn22KyVXcmpJGyk/wHBZxyKkn2YayGbvGQi3kzUYrmF+AA==",
-			"requires": {
-				"mrm-core": "^4.1.2"
-			}
-		},
 		"mute-stream": {
 			"version": "0.0.8",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -1184,6 +1027,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -1346,6 +1194,19 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.4.tgz",
 			"integrity": "sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA=="
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
 		},
 		"sigmund": {
 			"version": "1.0.1",
@@ -1609,6 +1470,14 @@
 			"integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
 			"requires": {
 				"lodash": "^4.17.15"
+			}
+		},
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"requires": {
+				"isexe": "^2.0.0"
 			}
 		},
 		"widest-line": {

--- a/packages/mrm/package.json
+++ b/packages/mrm/package.json
@@ -19,6 +19,7 @@
     "src"
   ],
   "dependencies": {
+    "cross-spawn": "7.0.3",
     "git-username": "^1.0.0",
     "glob": "^7.1.6",
     "inquirer": "^7.0.4",
@@ -31,6 +32,7 @@
     "minimist": "^1.2.0",
     "mrm-core": "^4.1.2",
     "mrm-preset-default": "^2.2.1",
+    "package-json": "6.5.0",
     "requireg": "^0.2.2",
     "semver-utils": "^1.1.4",
     "update-notifier": "^4.1.0",

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -126,35 +126,28 @@ describe('tryResolve', () => {
 describe('installGlobalPackage', () => {
 	it('should resolve to true if able to install the package', async () => {
 		spawn.mockReturnValueOnce({ on: spawnOnErrorMock });
-		const pkgName = String(Date.now());
+		const pkgName = 'mrm-preset-default';
 		const result = await installGlobalPackage(pkgName);
 		expect(spawn).toBeCalledWith('npm', ['install', '--global', pkgName], {
 			stdio: 'inherit',
 		});
-		expect(spawnOnErrorMock.mock.calls[0][0]).toBe('error');
-		expect(spawnOnErrorMock.mock.calls[0][1]).toBeInstanceOf(Function);
-		expect(spawnOnCloseMock.mock.calls[0][0]).toBe('close');
-		expect(spawnOnCloseMock.mock.calls[0][1]).toBeInstanceOf(Function);
 		expect(result).toBeTruthy();
 	});
 
-	it('should reject if unable able to install the package', async () => {
+	it('should reject if unable able to install the package', () => {
 		spawn.mockReturnValueOnce({ on: spawnOnErrorMock });
-		const error = Date.now();
+		const error = new Error('failed install');
 		spawnOnErrorMock.mockImplementation((_, cb) => {
 			cb(error);
 		});
 		spawnOnCloseMock.mockImplementation(() => {});
-		const pkgName = String(Date.now());
 
-		try {
-			await installGlobalPackage(pkgName);
-			throw new Error('Should have thrown');
-		} catch (err) {
-			expect(err).toBe(error);
-		}
+		return expect(installGlobalPackage('mrm-preset-default')).rejects.toThrow(
+			error
+		);
 	});
 });
+
 describe('getGlobalPackageName', () => {
 	it('should resolve to the package name if selected by the user and it can be installed', async () => {
 		configureInquirer({ pkgName: 'mrm-preset-default' });

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -112,6 +112,11 @@ describe('tryResolve', () => {
 		expect(result).toMatch('node_modules/listify/index.js');
 	});
 
+	it('should return undefined if none of the npm mudules are installed', () => {
+		const result = tryResolve('pizza', 'cappuccino');
+		expect(result).toBeFalsy();
+	});
+
 	it('should not throw when undefined was passed instead of a module name', () => {
 		const fn = () => tryResolve(undefined);
 		expect(fn).not.toThrowError();
@@ -375,10 +380,10 @@ describe('getConfigGetter (deprecated)', () => {
 	});
 
 	it('values function should return options object', () => {
-		const options = { coffee: 'americano' };
-		const config = getConfigGetter(options);
+		const opts = { coffee: 'americano' };
+		const config = getConfigGetter(opts);
 		const result = config.values();
-		expect(result).toEqual(options);
+		expect(result).toEqual(opts);
 	});
 
 	it('require function should not throw if all config options are defined', () => {
@@ -436,6 +441,17 @@ describe('runTask', () => {
 				})
 				.catch(reject);
 		});
+	});
+
+	it('should throw when module not found', () => {
+		const pizza = runTask('pizza', directories, {}, {});
+
+		// ideally we can use toThrowError but that works with >= jest@22
+		// https://github.com/facebook/jest/issues/5076
+		return expect(pizza).rejects.toHaveProperty(
+			'message',
+			'Task “pizza” not found.'
+		);
 	});
 
 	it('should throw when task module is invalid', () => {

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -17,6 +17,7 @@ const {
 	getAllAliases,
 	getAllTasks,
 	getPackageName,
+	getGlobalPackageName,
 } = require('../index');
 const configureInquirer = require('../../test/inquirer-mock');
 const task1 = require('../../test/dir1/task1');
@@ -85,25 +86,42 @@ describe('tryFile', () => {
 });
 
 describe('tryResolve', () => {
-	it('should resolve an npm module if it’s installed', async () => {
-		const result = await tryResolve('listify');
+	it('should resolve an npm module if it’s installed', () => {
+		const result = tryResolve('listify');
 		expect(result).toMatch('node_modules/listify/index.js');
 	});
 
-	it('should resolve the first installed npm module', async () => {
-		const result = await tryResolve('pizza', 'listify');
+	it('should resolve the first installed npm module', () => {
+		const result = tryResolve('pizza', 'listify');
 		expect(result).toMatch('node_modules/listify/index.js');
-	});
-
-	it('should return undefined if none of the npm modules are installed', async () => {
-		configureInquirer({ pkgName: false });
-		const result = await tryResolve('pizza', 'cappuccino');
-		expect(result).toBeFalsy();
 	});
 
 	it('should not throw when undefined was passed instead of a module name', () => {
 		const fn = () => tryResolve(undefined);
 		expect(fn).not.toThrowError();
+	});
+});
+
+describe('getGlobalPackageName', () => {
+	it('should resolve to the package name if selected by the user and it can be installed', async () => {
+		configureInquirer({ pkgName: 'mrm-preset-default' });
+		const result = await getGlobalPackageName(
+			'mrm-preset-default',
+			'pizza',
+			''
+		);
+		expect(result).toMatch('mrm-preset-default');
+	});
+
+	it('should resolve to undefined if none of the packages are selected', async () => {
+		configureInquirer({ pkgName: '' });
+		const result = await getGlobalPackageName('pizza', 'cappuccino');
+		expect(result).toBeFalsy();
+	});
+
+	it('should resolve to undefined if none of the npm modules exist', async () => {
+		const result = await getGlobalPackageName('');
+		expect(result).toBeFalsy();
 	});
 });
 

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -85,18 +85,19 @@ describe('tryFile', () => {
 });
 
 describe('tryResolve', () => {
-	it('should resolve an npm module if it’s installed', () => {
-		const result = tryResolve('listify');
+	it('should resolve an npm module if it’s installed', async () => {
+		const result = await tryResolve('listify');
 		expect(result).toMatch('node_modules/listify/index.js');
 	});
 
-	it('should resolve the first installed npm module', () => {
-		const result = tryResolve('pizza', 'listify');
+	it('should resolve the first installed npm module', async () => {
+		const result = await tryResolve('pizza', 'listify');
 		expect(result).toMatch('node_modules/listify/index.js');
 	});
 
-	it('should return undefined if none of the npm mudules are installed', () => {
-		const result = tryResolve('pizza', 'cappuccino');
+	it('should return undefined if none of the npm modules are installed', async () => {
+		configureInquirer({ pkgName: false });
+		const result = await tryResolve('pizza', 'cappuccino');
 		expect(result).toBeFalsy();
 	});
 
@@ -369,17 +370,6 @@ describe('runTask', () => {
 				})
 				.catch(reject);
 		});
-	});
-
-	it('should throw when module not found', () => {
-		const pizza = runTask('pizza', directories, {}, {});
-
-		// ideally we can use toThrowError but that works with >= jest@22
-		// https://github.com/facebook/jest/issues/5076
-		return expect(pizza).rejects.toHaveProperty(
-			'message',
-			'Task “pizza” not found.'
-		);
 	});
 
 	it('should throw when task module is invalid', () => {

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -373,12 +373,12 @@ async function tryResolve(...names) {
 	}
 
 	const possibleGlobals = await Promise.all(
-		names.map(name => packageJson(name).catch(() => {}))
+		names.map(name => packageJson(name).catch(() => null))
 	);
+
 	/**
 	 * @type packageJson.AbbreviatedMetadata[]
 	 */
-	// @ts-ignore
 	const choices = possibleGlobals.filter(Boolean);
 
 	const { pkgName } = await inquirer.prompt([
@@ -386,17 +386,17 @@ async function tryResolve(...names) {
 			name: 'pkgName',
 			type: 'list',
 			message:
-				"A task or preset you're trying to run isn't installed. Would you like to globally install it from npm?",
-			// @ts-ignore
+				'A task or preset you’re trying to run isn’t installed. Would you like to globally install it from npm?',
 			choices: choices
 				.map(({ name }) => ({ name, value: name }))
 				.concat({
-					name: "Don't install any packages",
-					value: false,
+					name: 'Don’t install any packages',
+					value: '',
 				}),
 		},
 	]);
-	if (pkgName === false) {
+
+	if (pkgName === '') {
 		return undefined;
 	}
 

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -382,7 +382,7 @@ async function getGlobalPackageName(...packageNames) {
 	const choices = possibleGlobals.filter(Boolean);
 
 	if (choices.length === 0) {
-		// No packages found on NPM
+		// No packages found on npm
 		return undefined;
 	}
 

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -381,37 +381,22 @@ async function tryResolve(...names) {
 	// @ts-ignore
 	const choices = possibleGlobals.filter(Boolean);
 
-	let questions;
-	if (choices.length === 1) {
-		// @ts-ignore
-		const pkgName = choices[0].name;
-		questions = [
-			{
-				name: 'pkgName',
-				message: `Found a package named ${pkgName} on NPM would you like to install it globally?`,
-				type: 'confirm',
-			},
-		];
-	} else {
-		questions = [
-			{
-				name: 'pkgName',
-				message: `Which package would you like to install globally?`,
-				// @ts-ignore
-				choices: choices
-					.map(({ name }) => ({ name, value: name }))
-					.concat({
-						name: 'I do not want to install any these packages',
-						value: false,
-					}),
-				type: 'list',
-			},
-		];
-	}
-	let { pkgName } = await inquirer.prompt(questions);
-	if (pkgName === true) {
-		pkgName = choices[0].name;
-	} else if (pkgName === false) {
+	const { pkgName } = await inquirer.prompt([
+		{
+			name: 'pkgName',
+			type: 'list',
+			message:
+				"A task or preset you're trying to run isn't installed. Would you like to globally install it from npm?",
+			// @ts-ignore
+			choices: choices
+				.map(({ name }) => ({ name, value: name }))
+				.concat({
+					name: "Don't install any packages",
+					value: false,
+				}),
+		},
+	]);
+	if (pkgName === false) {
 		return undefined;
 	}
 

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -397,7 +397,13 @@ async function tryResolve(...names) {
 			{
 				name: 'pkgName',
 				message: `Which package would you like to install globally?`,
-				choices: choices.map(({ name }) => name),
+				// @ts-ignore
+				choices: choices
+					.map(({ name }) => ({ name, value: name }))
+					.concat({
+						name: 'I do not want to install any these packages',
+						value: false,
+					}),
 				type: 'list',
 			},
 		];


### PR DESCRIPTION
This is just a PoC for now, definitely could be better built out. This will try to install a preset or task package globally if it is found on NPM (including namespaced packages), Prompting the user first if this is desired.

Rel: https://github.com/sapegin/mrm/issues/59
