### PR TITLE
update mrm-task-license — add new entry for author name

### DIFF
--- a/packages/mrm-task-license/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-license/__snapshots__/index.spec.js.snap
@@ -13,7 +13,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 "
 `;
 
-exports[`should read lincese name from package.json 1`] = `
+exports[`should read license name from package.json 1`] = `
 "# Apache License, Version 2.0 (Apache-2.0)
 
 Copyright 2020 Gendalf, contributors

--- a/packages/mrm-task-license/index.js
+++ b/packages/mrm-task-license/index.js
@@ -7,18 +7,32 @@ const defaultLicense = 'MIT';
 
 const ANONYMOUS_LICENSES = ['Unlicense'];
 
-const isAnonymouseLicense = name => ANONYMOUS_LICENSES.indexOf(name) > -1;
+const isAnonymousLicense = name => ANONYMOUS_LICENSES.includes(name);
+
+function getAuthorName() {
+	const pkg = packageJson();
+	const authorRegExp = /\(.*\)|<.*>/g;
+
+	if (typeof pkg.get('author') === 'string') {
+		return pkg
+			.get('author')
+			.replace(authorRegExp, '')
+			.trim();
+	}
+
+	return pkg.get('author.name');
+}
 
 function task(config) {
 	const pkg = packageJson();
 	config
 		.defaults({ licenseFile: 'License.md' })
-		.defaults({ name: pkg.get('author.name') })
+		.defaults({ name: getAuthorName() })
 		.defaults(meta);
 
 	const configLicense = config.values().license;
 
-	if (!isAnonymouseLicense(configLicense)) {
+	if (!isAnonymousLicense(configLicense)) {
 		config.require('name', 'email');
 	}
 
@@ -54,3 +68,4 @@ function task(config) {
 task.description = 'Adds license file';
 
 module.exports = task;
+module.exports.getAuthorName = getAuthorName;

--- a/packages/mrm-task-license/index.js
+++ b/packages/mrm-task-license/index.js
@@ -9,8 +9,7 @@ const ANONYMOUS_LICENSES = ['Unlicense'];
 
 const isAnonymousLicense = name => ANONYMOUS_LICENSES.includes(name);
 
-function getAuthorName() {
-	const pkg = packageJson();
+function getAuthorName(pkg) {
 	const authorRegExp = /\(.*\)|<.*>/g;
 
 	if (typeof pkg.get('author') === 'string') {
@@ -27,7 +26,7 @@ function task(config) {
 	const pkg = packageJson();
 	config
 		.defaults({ licenseFile: 'License.md' })
-		.defaults({ name: getAuthorName() })
+		.defaults({ name: getAuthorName(pkg) })
 		.defaults(meta);
 
 	const configLicense = config.values().license;

--- a/packages/mrm-task-license/index.spec.js
+++ b/packages/mrm-task-license/index.spec.js
@@ -8,6 +8,7 @@ const path = require('path');
 const { getConfigGetter } = require('mrm');
 const vol = require('memfs').vol;
 const task = require('./index');
+const getAuthorName = require('./index').getAuthorName;
 const { json } = require('mrm-core');
 
 const console$log = console.log;
@@ -95,4 +96,22 @@ it('adds license to package.json if not set', () => {
 	task(getConfigGetter(config));
 
 	expect(json('/package.json').get('license')).toBe('MIT');
+});
+
+it.each([
+	['Barney Rubble <example@name.com> (http://example.com/)', 'Barney Rubble'],
+	['Barney Rubble (http://example.com/)', 'Barney Rubble'],
+	['Barney Rubble <example@name.com>', 'Barney Rubble'],
+	['Barney Rubble ', 'Barney Rubble'],
+	[{ name: 'Barney Rubble' }, 'Barney Rubble'],
+])('Should get author name form package.json', (field, expected) => {
+	vol.fromJSON({
+		'/package.json': stringify({
+			author: field,
+		}),
+	});
+
+	const authorName = getAuthorName();
+
+	expect(authorName).toBe(expected);
 });

--- a/packages/mrm-task-license/index.spec.js
+++ b/packages/mrm-task-license/index.spec.js
@@ -42,7 +42,7 @@ it('should add EditorConfig', () => {
 	expect(vol.toJSON()['/License.md']).toMatchSnapshot();
 });
 
-it('should read lincese name from package.json', () => {
+it('should read license name from package.json', () => {
 	vol.fromJSON({
 		[`${__dirname}/templates/Apache-2.0.md`]: fs
 			.readFileSync(path.join(__dirname, 'templates/Apache-2.0.md'))
@@ -99,19 +99,22 @@ it('adds license to package.json if not set', () => {
 });
 
 it.each([
-	['Barney Rubble <example@name.com> (http://example.com/)', 'Barney Rubble'],
-	['Barney Rubble (http://example.com/)', 'Barney Rubble'],
-	['Barney Rubble <example@name.com>', 'Barney Rubble'],
-	['Barney Rubble ', 'Barney Rubble'],
-	[{ name: 'Barney Rubble' }, 'Barney Rubble'],
+	[
+		{ author: 'Barney Rubble <example@name.com> (http://example.com/)' },
+		'Barney Rubble',
+	],
+	[{ author: 'Barney Rubble (http://example.com/)' }, 'Barney Rubble'],
+	[{ author: 'Barney Rubble <example@name.com>' }, 'Barney Rubble'],
+	[{ author: 'Barney Rubble ' }, 'Barney Rubble'],
+	[{ author: { name: 'Barney Rubble' } }, 'Barney Rubble'],
+	[{ author: undefined }, undefined],
+	[undefined, undefined],
 ])('Should get author name form package.json', (field, expected) => {
 	vol.fromJSON({
-		'/package.json': stringify({
-			author: field,
-		}),
+		'/package.json': stringify(Object.assign({}, field)),
 	});
 
-	const authorName = getAuthorName();
+	const authorName = getAuthorName(json('/package.json'));
 
 	expect(authorName).toBe(expected);
 });


### PR DESCRIPTION
Hi!
Base on npm documentation: https://docs.npmjs.com/files/package.json#people-fields-author-contributors, author field can be an object on an string. In this PR try to add this behavior to mrm task license