### PR TITLE
Accept more types of eslint presets

### DIFF
--- a/packages/mrm-task-eslint/Readme.md
+++ b/packages/mrm-task-eslint/Readme.md
@@ -25,7 +25,7 @@ See [Mrm docs](../../docs/Getting_started.md) for more details.
 
 ### `eslintPreset` (default: `eslint:recommended`)
 
-ESLint preset name (not npm package name, e.g. `airbnb`).
+ESLint preset name (e.g. `airbnb` or `eslint-config-airbnb`).
 
 ### `eslintPeerDependencies` (optional)
 

--- a/packages/mrm-task-eslint/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-eslint/__snapshots__/index.spec.js.snap
@@ -212,8 +212,68 @@ Object {
 }
 `;
 
-exports[`should use a custom preset 1`] = `
+exports[`should use custom preset \`@scoped/custom-config-name/variant\` 1`] = `
+"{
+  \\"extends\\": \\"@scoped/custom-config-name/variant\\"
+}"
+`;
+
+exports[`should use custom preset \`@scoped/custom-config-name\` 1`] = `
+"{
+  \\"extends\\": \\"@scoped/custom-config-name\\"
+}"
+`;
+
+exports[`should use custom preset \`@scoped/eslint-config/variant\` 1`] = `
+"{
+  \\"extends\\": \\"@scoped/eslint-config/variant\\"
+}"
+`;
+
+exports[`should use custom preset \`@scoped/eslint-config\` 1`] = `
+"{
+  \\"extends\\": \\"@scoped/eslint-config\\"
+}"
+`;
+
+exports[`should use custom preset \`@scoped/eslint-config-alt/variant\` 1`] = `
+"{
+  \\"extends\\": \\"@scoped/eslint-config-alt/variant\\"
+}"
+`;
+
+exports[`should use custom preset \`@scoped/eslint-config-alt\` 1`] = `
+"{
+  \\"extends\\": \\"@scoped/eslint-config-alt\\"
+}"
+`;
+
+exports[`should use custom preset \`@scoped\` 1`] = `
+"{
+  \\"extends\\": \\"@scoped\\"
+}"
+`;
+
+exports[`should use custom preset \`airbnb/whitespace\` 1`] = `
+"{
+  \\"extends\\": \\"airbnb/whitespace\\"
+}"
+`;
+
+exports[`should use custom preset \`airbnb\` 1`] = `
 "{
   \\"extends\\": \\"airbnb\\"
+}"
+`;
+
+exports[`should use custom preset \`eslint-config-airbnb/whitespace\` 1`] = `
+"{
+  \\"extends\\": \\"eslint-config-airbnb/whitespace\\"
+}"
+`;
+
+exports[`should use custom preset \`eslint-config-airbnb\` 1`] = `
+"{
+  \\"extends\\": \\"eslint-config-airbnb\\"
 }"
 `;

--- a/packages/mrm-task-eslint/index.js
+++ b/packages/mrm-task-eslint/index.js
@@ -54,8 +54,7 @@ module.exports = function task({
 
 	// Preset
 	if (eslintPreset !== 'eslint:recommended') {
-		const presetPackage = normalizePresetPackageName(eslintPreset);
-		packages.push(presetPackage);
+		packages.push(normalizePresetPackageName(eslintPreset));
 	}
 
 	// Peer dependencies

--- a/packages/mrm-task-eslint/index.js
+++ b/packages/mrm-task-eslint/index.js
@@ -14,7 +14,9 @@ const normalizePresetPackageName = presetName => {
 	const match = presetName.match(presetNameRegex);
 
 	if (!match) {
-		throw new Error('Invalid preset name');
+		throw new Error(
+			`Invalid preset name is passed to the eslint task: ${presetName}`
+		);
 	}
 
 	const scope = match[1] || '';

--- a/packages/mrm-task-eslint/index.js
+++ b/packages/mrm-task-eslint/index.js
@@ -8,6 +8,16 @@ const {
 	getExtsFromCommand,
 } = require('mrm-core');
 
+const getConfigName = (configName, scope, prefix) => {
+	if (!scope && !configName.startsWith(prefix)) {
+		return `${prefix}-${configName}`;
+	} else if (scope && !configName) {
+		return prefix;
+	} else {
+		return configName;
+	}
+};
+
 const normalizePresetPackageName = presetName => {
 	const prefix = 'eslint-config';
 	const presetNameRegex = /^(?:(@[^/]+)\/?)?((?:eslint-config-)?[^/]*)(?:\/[^/]+)?$/;
@@ -19,14 +29,8 @@ const normalizePresetPackageName = presetName => {
 		);
 	}
 
-	const scope = match[1] || '';
-	let configName = match[2];
-
-	if (!scope && !configName.startsWith(prefix)) {
-		configName = `${prefix}-${configName}`;
-	} else if (scope && !configName) {
-		configName = prefix;
-	}
+	const [, scope = '', configNameRaw] = match;
+	const configName = getConfigName(configNameRaw, scope, prefix);
 
 	const packageName = `${scope ? `${scope}/` : ''}${configName}`;
 

--- a/packages/mrm-task-eslint/index.js
+++ b/packages/mrm-task-eslint/index.js
@@ -8,6 +8,29 @@ const {
 	getExtsFromCommand,
 } = require('mrm-core');
 
+const normalizePresetPackageName = presetName => {
+	const prefix = 'eslint-config';
+	const presetNameRegex = /^(?:(@[^/]+)\/?)?((?:eslint-config-)?[^/]*)(?:\/[^/]+)?$/;
+	const match = presetName.match(presetNameRegex);
+
+	if (!match) {
+		throw new Error('Invalid preset name');
+	}
+
+	const scope = match[1] || '';
+	let configName = match[2];
+
+	if (!scope && !configName.startsWith(prefix)) {
+		configName = `${prefix}-${configName}`;
+	} else if (scope && !configName) {
+		configName = prefix;
+	}
+
+	const packageName = `${scope ? `${scope}/` : ''}${configName}`;
+
+	return packageName;
+};
+
 module.exports = function task({
 	eslintPreset,
 	eslintPeerDependencies,
@@ -25,7 +48,8 @@ module.exports = function task({
 
 	// Preset
 	if (eslintPreset !== 'eslint:recommended') {
-		packages.push(`eslint-config-${eslintPreset}`);
+		const presetPackage = normalizePresetPackageName(eslintPreset);
+		packages.push(presetPackage);
 	}
 
 	// Peer dependencies

--- a/packages/mrm-task-eslint/index.spec.js
+++ b/packages/mrm-task-eslint/index.spec.js
@@ -64,6 +64,13 @@ it.each([
 	expect(install).toBeCalledWith(['eslint', packageName]);
 });
 
+it('should throw when given a file path for the preset name', async () => {
+	const options = await getTaskOptions(task, false, {
+		eslintPreset: './path/to/config',
+	});
+	expect(() => task(options)).toThrow();
+});
+
 it('should not add a custom preset if it’s already there', async () => {
 	vol.fromJSON({
 		'/package.json': packageJson,

--- a/packages/mrm-task-eslint/index.spec.js
+++ b/packages/mrm-task-eslint/index.spec.js
@@ -41,15 +41,27 @@ it('should add ESLint', async () => {
 	expect(install).toBeCalledWith(['eslint']);
 });
 
-it('should use a custom preset', async () => {
+it.each([
+	['airbnb', 'eslint-config-airbnb'],
+	['airbnb/whitespace', 'eslint-config-airbnb'],
+	['eslint-config-airbnb', 'eslint-config-airbnb'],
+	['eslint-config-airbnb/whitespace', 'eslint-config-airbnb'],
+	['@scoped', '@scoped/eslint-config'],
+	['@scoped/eslint-config', '@scoped/eslint-config'],
+	['@scoped/eslint-config/variant', '@scoped/eslint-config'],
+	['@scoped/custom-config-name', '@scoped/custom-config-name'],
+	['@scoped/eslint-config-alt', '@scoped/eslint-config-alt'],
+	['@scoped/eslint-config-alt/variant', '@scoped/eslint-config-alt'],
+	['@scoped/custom-config-name/variant', '@scoped/custom-config-name'],
+])('should use custom preset `%s`', async (presetName, packageName) => {
 	vol.fromJSON({
 		'/package.json': packageJson,
 	});
 
-	task(await getTaskOptions(task, false, { eslintPreset: 'airbnb' }));
+	task(await getTaskOptions(task, false, { eslintPreset: presetName }));
 
 	expect(vol.toJSON()[configFile]).toMatchSnapshot();
-	expect(install).toBeCalledWith(['eslint', 'eslint-config-airbnb']);
+	expect(install).toBeCalledWith(['eslint', packageName]);
 });
 
 it('should not add a custom preset if it’s already there', async () => {


### PR DESCRIPTION
This change expands the set of eslint preset names accepted by the eslint task to be closer to [what is accepted by eslint for the `extends` configuration option](https://eslint.org/docs/developer-guide/shareable-configs) including scoped packages and intra-package configs (e.g. `eslint-config-airbnb/whitespace`). This change does not include support for presets specified by a file path.

It's worth noting that the [`@eslint/eslintrc`](https://github.com/eslint/eslintrc) package exports a `normalizePackageName` function, but there are a couple issues with that:
1. The package is explicitly marked as not for external use
2. The function does not handle intra-package configs 



