### PR TITLE
fix(mrm-core): Fix adding packages to yarn workspaces

### DIFF
--- a/packages/mrm-core/src/__tests__/npm.spec.js
+++ b/packages/mrm-core/src/__tests__/npm.spec.js
@@ -59,7 +59,13 @@ describe('install()', () => {
 		install(modules, { yarn: true }, spawn);
 		expect(spawn).toBeCalledWith(
 			expect.stringMatching(/yarn(\.cmd)?/),
-			['add', '--dev', 'eslint@latest', 'babel-core@latest'],
+			[
+				'add',
+				'--dev',
+				'--ignore-workspace-root-check',
+				'eslint@latest',
+				'babel-core@latest',
+			],
 			options
 		);
 	});
@@ -81,7 +87,12 @@ describe('install()', () => {
 		install(modules, { dev: false, yarn: true }, spawn);
 		expect(spawn).toBeCalledWith(
 			expect.stringMatching(/yarn(\.cmd)?/),
-			['add', 'eslint@latest', 'babel-core@latest'],
+			[
+				'add',
+				'--ignore-workspace-root-check',
+				'eslint@latest',
+				'babel-core@latest',
+			],
 			options
 		);
 	});
@@ -93,7 +104,13 @@ describe('install()', () => {
 		install(modules, undefined, spawn);
 		expect(spawn).toBeCalledWith(
 			expect.stringMatching(/yarn(\.cmd)?/),
-			['add', '--dev', 'eslint@latest', 'babel-core@latest'],
+			[
+				'add',
+				'--dev',
+				'--ignore-workspace-root-check',
+				'eslint@latest',
+				'babel-core@latest',
+			],
 			{
 				cwd: undefined,
 				stdio: 'inherit',

--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -117,7 +117,9 @@ function runNpm(deps, options = {}, exec) {
  * @param {Function} [exec]
  */
 function runYarn(deps, options = {}, exec) {
-	const add = options.dev ? ['add', '--dev'] : ['add'];
+	const add = options.dev
+		? ['add', '--dev', '--ignore-workspace-root-check']
+		: ['add', '--ignore-workspace-root-check'];
 	const remove = ['remove'];
 	const args = (options.remove ? remove : add).concat(deps);
 

--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -112,6 +112,12 @@ function runNpm(deps, options = {}, exec) {
 /**
  * Install given Yarn packages
  *
+ * This will use yarn's `--ignore-workspace-root-check` to allow additions of packages
+ * inside a repository that is using yarn's workspaces feature. If the current
+ * repository is _not_ using workspaces, then that flag is simply ignored.
+ *
+ * @see https://classic.yarnpkg.com/en/docs/cli/add/#toc-yarn-add-ignore-workspace-root-check-w
+ *
  * @param {string[]} deps
  * @param {RunOptions} [options]
  * @param {Function} [exec]


### PR DESCRIPTION
This fixes the issue of running any tasks that install additional packages while working in a yarn workspace. This will always add the flag [--ignore-workspace-root-check](https://classic.yarnpkg.com/en/docs/cli/add/#toc-yarn-add-ignore-workspace-root-check-w) to the `yarn add` commands. Adding this flag when yarn is not using workspaces will cause no effect, and does not break anything.

This likely resolves the issue in #48.