### PR TITLE
Removing mrm-task as keyword

### DIFF
--- a/docs/Making_presets.md
+++ b/docs/Making_presets.md
@@ -35,7 +35,7 @@ And the `package.json` would look like this:
   },
   "main": "config.json",
   "files": ["config.json", "*/index.js"],
-  "keywords": ["mrm", "mrm-task", "mrm-preset"],
+  "keywords": ["mrm", "mrm-preset"],
   "dependencies": {
     "mrm-core": "^2.1.3",
     "mrm-task-gitignore": "^0.1.0"


### PR DESCRIPTION
In my view, it dilutes the `mrm-task` category if adding presets into it. Better, imo, to use `mrm` if looking for a category that is generic to both tasks and presets.