### PR TITLE
feat(readme): Make contributing conditional by `includeContributing` option and allow `contributingFile` option for name

### DIFF
--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -159,9 +159,7 @@ function runYarn(deps, options = {}, exec) {
  * @param {Function} [exec]
  */
 function runYarnBerry(deps, options = {}, exec) {
-	const add = options.dev
-		? ['add', '--dev']
-		: ['add'];
+	const add = options.dev ? ['add', '--dev'] : ['add'];
 
 	const remove = ['remove'];
 	const args = (options.remove ? remove : add).concat(deps);

--- a/packages/mrm-task-license/package-lock.json
+++ b/packages/mrm-task-license/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "mrm-core": "^4.5.0",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       },
       "engines": {

--- a/packages/mrm-task-readme/Readme.md
+++ b/packages/mrm-task-readme/Readme.md
@@ -31,19 +31,27 @@ Your name.
 
 Your site URL.
 
-### `readmeFile` (default: `Readme.md`)
+### `readmeFile` (default: `"Readme.md"`)
 
 Name of the Readme file.
 
-### `license` (default: taken from `package.json`, if not found `MIT` is used)
+### `license` (default: taken from `package.json`, if not found `"MIT"` is used)
 
 License name (like `MIT`, `Unlicense`). For full list of supported values see: [`/templates`](https://github.com/sapegin/mrm/tree/master/packages/mrm-task-license/templates).
 
 This is only needed if `licenseFile` is used.
 
-### `licenseFile` (default: `License.md`)
+### `licenseFile` (default: `"License.md"`)
 
 Name of the license file. May use `${license}` within the string to insert the value of `license` dynamically into the name (to maintain this general template independently from the license type, while non-redundant with it).
+
+### `contributingFile` (default: `"Contributing.md"`)
+
+Name of the Contributing file.
+
+### `includeContributing` (default: `true`)
+
+Whether to include the Contributing text.
 
 ## Changelog
 

--- a/packages/mrm-task-readme/Readme.md
+++ b/packages/mrm-task-readme/Readme.md
@@ -51,7 +51,7 @@ Name of the Contributing file.
 
 ### `includeContributing` (default: `true`)
 
-Whether to include the Contributing text.
+Whether to include the Contributing section.
 
 ## Changelog
 

--- a/packages/mrm-task-readme/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-readme/__snapshots__/index.spec.js.snap
@@ -26,3 +26,53 @@ MIT License, see the included [License.md](License.md) file.
 }",
 }
 `;
+
+exports[`should add a readme without contributing 1`] = `
+Object {
+  "/Readme.md": "# unicorn
+
+...
+
+## Changelog
+
+The changelog can be found on the [Releases page](https://github.com/gandalf/unicorn/releases).
+
+## Authors and license
+
+[Gandalf](https://middleearth.com) and [contributors](https://github.com/gandalf/unicorn/graphs/contributors).
+
+MIT License, see the included [License.md](License.md) file.
+",
+  "/package.json": "{
+  \\"name\\": \\"unicorn\\",
+  \\"repository\\": \\"gandalf/unicorn\\"
+}",
+}
+`;
+
+exports[`should add a readme with custom contributing 1`] = `
+Object {
+  "/Readme.md": "# unicorn
+
+...
+
+## Changelog
+
+The changelog can be found on the [Releases page](https://github.com/gandalf/unicorn/releases).
+
+## Contributing
+
+Everyone is welcome to contribute. Please take a moment to review the [contributing guidelines](CONTRIBUTIONS.md).
+
+## Authors and license
+
+[Gandalf](https://middleearth.com) and [contributors](https://github.com/gandalf/unicorn/graphs/contributors).
+
+MIT License, see the included [License.md](License.md) file.
+",
+  "/package.json": "{
+  \\"name\\": \\"unicorn\\",
+  \\"repository\\": \\"gandalf/unicorn\\"
+}",
+}
+`;

--- a/packages/mrm-task-readme/index.js
+++ b/packages/mrm-task-readme/index.js
@@ -3,20 +3,34 @@ const meta = require('user-meta');
 const parseAuthor = require('parse-author');
 const packageRepoUrl = require('package-repo-url');
 const { template, packageJson } = require('mrm-core');
-const { template: smplTemplate } = require('smpltmpl');
+const { template: smplTemplate, templateFromFile } = require('smpltmpl');
 
 function getAuthorName(pkg) {
 	const rawName = pkg.get('author.name') || pkg.get('author') || '';
 	return parseAuthor(rawName).name;
 }
 
-function task({ packageName, name, url, readmeFile, licenseFile, license }) {
+function task({
+	packageName,
+	name,
+	url,
+	readmeFile,
+	licenseFile,
+	license,
+	includeContributing,
+	contributingFile,
+}) {
 	// Create Readme.md (no update)
 	const readme = template(
 		readmeFile,
 		path.join(__dirname, 'templates/Readme.md')
 	);
 	if (!readme.exists()) {
+		const contributingTemplate = includeContributing
+			? templateFromFile(path.join(__dirname, 'templates/Contributing.md'), {
+					contributingFile,
+			  })
+			: '';
 		readme
 			.apply({
 				name,
@@ -26,6 +40,7 @@ function task({ packageName, name, url, readmeFile, licenseFile, license }) {
 					license,
 				}),
 				package: packageName,
+				contributing: '\n' + contributingTemplate,
 			})
 			.save();
 	}
@@ -58,6 +73,16 @@ module.exports.parameters = {
 		validate(value) {
 			return value ? true : 'Site URL is required';
 		},
+	},
+	includeContributing: {
+		type: 'confirm',
+		message: 'Include Contributing section linking to Contributing file?',
+		default: true,
+	},
+	contributingFile: {
+		type: 'input',
+		message: 'Enter filename for the contributing file',
+		default: 'Contributing.md',
 	},
 	readmeFile: {
 		type: 'input',

--- a/packages/mrm-task-readme/index.js
+++ b/packages/mrm-task-readme/index.js
@@ -27,7 +27,8 @@ function task({
 	);
 	if (!readme.exists()) {
 		const contributingTemplate = includeContributing
-			? templateFromFile(path.join(__dirname, 'templates/Contributing.md'), {
+			? '\n' +
+			  templateFromFile(path.join(__dirname, 'templates/Contributing.md'), {
 					contributingFile,
 			  })
 			: '';
@@ -40,7 +41,7 @@ function task({
 					license,
 				}),
 				package: packageName,
-				contributing: '\n' + contributingTemplate,
+				contributing: contributingTemplate,
 			})
 			.save();
 	}

--- a/packages/mrm-task-readme/index.js
+++ b/packages/mrm-task-readme/index.js
@@ -27,8 +27,7 @@ function task({
 	);
 	if (!readme.exists()) {
 		const contributingTemplate = includeContributing
-			? '\n' +
-			  templateFromFile(path.join(__dirname, 'templates/Contributing.md'), {
+			? templateFromFile(path.join(__dirname, 'templates/Contributing.md'), {
 					contributingFile,
 			  })
 			: '';

--- a/packages/mrm-task-readme/index.spec.js
+++ b/packages/mrm-task-readme/index.spec.js
@@ -20,6 +20,9 @@ it('should add a readme', async () => {
 		[`${__dirname}/templates/Readme.md`]: fs
 			.readFileSync(path.join(__dirname, 'templates/Readme.md'))
 			.toString(),
+		[`${__dirname}/templates/Contributing.md`]: fs
+			.readFileSync(path.join(__dirname, 'templates/Contributing.md'))
+			.toString(),
 		'/package.json': stringify({
 			name: 'unicorn',
 			repository: 'gandalf/unicorn',

--- a/packages/mrm-task-readme/index.spec.js
+++ b/packages/mrm-task-readme/index.spec.js
@@ -46,6 +46,9 @@ it('should add a readme with custom file name', async () => {
 		[`${__dirname}/templates/Readme.md`]: fs
 			.readFileSync(path.join(__dirname, 'templates/Readme.md'))
 			.toString(),
+		[`${__dirname}/templates/Contributing.md`]: fs
+			.readFileSync(path.join(__dirname, 'templates/Contributing.md'))
+			.toString(),
 		'/package.json': stringify({
 			name: 'unicorn',
 			repository: 'gandalf/unicorn',

--- a/packages/mrm-task-readme/index.spec.js
+++ b/packages/mrm-task-readme/index.spec.js
@@ -65,3 +65,54 @@ it('should add a readme with custom file name', async () => {
 		'[LICENSE-MIT.md](LICENSE-MIT.md)'
 	);
 });
+
+it('should add a readme without contributing', async () => {
+	vol.fromJSON({
+		[`${__dirname}/templates/Readme.md`]: fs
+			.readFileSync(path.join(__dirname, 'templates/Readme.md'))
+			.toString(),
+		'/package.json': stringify({
+			name: 'unicorn',
+			repository: 'gandalf/unicorn',
+		}),
+	});
+
+	task(
+		await getTaskOptions(task, false, {
+			name: 'Gandalf',
+			url: 'https://middleearth.com',
+			includeContributing: false,
+		})
+	);
+
+	expect(
+		omitBy(vol.toJSON(), (v, k) => k.startsWith(__dirname))
+	).toMatchSnapshot();
+});
+
+it('should add a readme with custom contributing', async () => {
+	vol.fromJSON({
+		[`${__dirname}/templates/Readme.md`]: fs
+			.readFileSync(path.join(__dirname, 'templates/Readme.md'))
+			.toString(),
+		[`${__dirname}/templates/Contributing.md`]: fs
+			.readFileSync(path.join(__dirname, 'templates/Contributing.md'))
+			.toString(),
+		'/package.json': stringify({
+			name: 'unicorn',
+			repository: 'gandalf/unicorn',
+		}),
+	});
+
+	task(
+		await getTaskOptions(task, false, {
+			name: 'Gandalf',
+			url: 'https://middleearth.com',
+			contributingFile: 'CONTRIBUTIONS.md',
+		})
+	);
+
+	expect(
+		omitBy(vol.toJSON(), (v, k) => k.startsWith(__dirname))
+	).toMatchSnapshot();
+});

--- a/packages/mrm-task-readme/package-lock.json
+++ b/packages/mrm-task-readme/package-lock.json
@@ -12,6 +12,7 @@
         "mrm-core": "^4.5.0",
         "package-repo-url": "^1.0.3",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       },
       "engines": {

--- a/packages/mrm-task-readme/templates/Contributing.md
+++ b/packages/mrm-task-readme/templates/Contributing.md
@@ -1,0 +1,3 @@
+## Contributing
+
+Everyone is welcome to contribute. Please take a moment to review the [contributing guidelines](${contributingFile}).

--- a/packages/mrm-task-readme/templates/Readme.md
+++ b/packages/mrm-task-readme/templates/Readme.md
@@ -5,11 +5,7 @@
 ## Changelog
 
 The changelog can be found on the [Releases page](${github}/releases).
-
-## Contributing
-
-Everyone is welcome to contribute. Please take a moment to review the [contributing guidelines](Contributing.md).
-
+${contributing}
 ## Authors and license
 
 [${name}](${url}) and [contributors](${github}/graphs/contributors).

--- a/packages/mrm-task-readme/templates/Readme.md
+++ b/packages/mrm-task-readme/templates/Readme.md
@@ -5,7 +5,7 @@
 ## Changelog
 
 The changelog can be found on the [Releases page](${github}/releases).
-${contributing}
+${contributing && '\n' + contributing}
 ## Authors and license
 
 [${name}](${url}) and [contributors](${github}/graphs/contributors).


### PR DESCRIPTION
I didn't know if you might want `smpltmpl` exposed from `mrm-core`, so added as a direct dependency for now (also whether you'd like a `cross-spawn` utility in core as I think might be useful to expose).

Thanks!