### PR TITLE
feat(license): file name template-based

### DIFF
--- a/packages/mrm-task-license/Readme.md
+++ b/packages/mrm-task-license/Readme.md
@@ -25,7 +25,7 @@ License name (like `MIT`, `Unlicense`). For full list of supported values see: [
 
 ### `licenseFile` (default: `License.md`)
 
-File name.
+File name. May use `${license}` within the string to insert the value of `license` dynamically into the name (to maintain this general template independently from the license type, while non-redundant with it).
 
 ### `name` (default: will try to read from your npm or Git config)
 

--- a/packages/mrm-task-license/index.js
+++ b/packages/mrm-task-license/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 const meta = require('user-meta');
 const parseAuthor = require('parse-author');
 const { template, packageJson } = require('mrm-core');
+const { template: smplTemplate } = require('smpltmpl');
 
 function getAuthorName(pkg) {
 	const rawName = pkg.get('author.name') || pkg.get('author') || '';
@@ -17,7 +18,12 @@ function task({ license, name, email, licenseFile }) {
 		return;
 	}
 
-	template(licenseFile, templateFile)
+	template(
+		smplTemplate(licenseFile, {
+			license,
+		}),
+		templateFile
+	)
 		.apply({
 			name,
 			email,

--- a/packages/mrm-task-license/index.spec.js
+++ b/packages/mrm-task-license/index.spec.js
@@ -45,6 +45,26 @@ test('adds a license file with author details', async () => {
 	);
 });
 
+test('adds a license file with custom, dynamic file name', async () => {
+	vol.fromJSON({
+		[`${__dirname}/templates/MIT.md`]: fs
+			.readFileSync(path.join(__dirname, 'templates/MIT.md'))
+			.toString(),
+	});
+
+	task(
+		await getTaskOptions(task, false, {
+			...config,
+			licenseFile: 'LICENSE-${license.toUpperCase()}.md',
+		})
+	);
+
+	expect(vol.toJSON()['/LICENSE-MIT.md']).toMatch(/The MIT License/);
+	expect(vol.toJSON()['/LICENSE-MIT.md']).toMatch(
+		/Copyright 2\d\d\d Gendalf, contributors/
+	);
+});
+
 test('reads license name from package.json', async () => {
 	vol.fromJSON({
 		[`${__dirname}/templates/Apache-2.0.md`]: fs

--- a/packages/mrm-task-license/package.json
+++ b/packages/mrm-task-license/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "mrm-core": "^4.5.0",
     "parse-author": "^2.0.0",
+    "smpltmpl": "^1.0.2",
     "user-meta": "^1.0.0"
   }
 }

--- a/packages/mrm-task-readme/Readme.md
+++ b/packages/mrm-task-readme/Readme.md
@@ -35,9 +35,15 @@ Your site URL.
 
 Name of the Readme file.
 
+### `license` (default: taken from `package.json`, if not found `MIT` is used)
+
+License name (like `MIT`, `Unlicense`). For full list of supported values see: [`/templates`](https://github.com/sapegin/mrm/tree/master/packages/mrm-task-license/templates).
+
+This is only needed if `licenseFile` is used.
+
 ### `licenseFile` (default: `License.md`)
 
-Name of the license file.
+Name of the license file. May use `${license}` within the string to insert the value of `license` dynamically into the name (to maintain this general template independently from the license type, while non-redundant with it).
 
 ## Changelog
 

--- a/packages/mrm-task-readme/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-readme/__snapshots__/index.spec.js.snap
@@ -26,3 +26,30 @@ MIT License, see the included [License.md](License.md) file.
 }",
 }
 `;
+
+exports[`should add a readme with custom file name 1`] = `
+Object {
+  "/Readme.md": "# unicorn
+
+...
+
+## Changelog
+
+The changelog can be found on the [Releases page](https://github.com/gandalf/unicorn/releases).
+
+## Contributing
+
+Everyone is welcome to contribute. Please take a moment to review the [contributing guidelines](Contributing.md).
+
+## Authors and license
+
+[Gandalf](https://middleearth.com) and [contributors](https://github.com/gandalf/unicorn/graphs/contributors).
+
+MIT License, see the included [LICENSE-MIT.md](LICENSE-MIT.md) file.
+",
+  "/package.json": "{
+  \\"name\\": \\"unicorn\\",
+  \\"repository\\": \\"gandalf/unicorn\\"
+}",
+}
+`;

--- a/packages/mrm-task-readme/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-readme/__snapshots__/index.spec.js.snap
@@ -26,30 +26,3 @@ MIT License, see the included [License.md](License.md) file.
 }",
 }
 `;
-
-exports[`should add a readme with custom file name 1`] = `
-Object {
-  "/Readme.md": "# unicorn
-
-...
-
-## Changelog
-
-The changelog can be found on the [Releases page](https://github.com/gandalf/unicorn/releases).
-
-## Contributing
-
-Everyone is welcome to contribute. Please take a moment to review the [contributing guidelines](Contributing.md).
-
-## Authors and license
-
-[Gandalf](https://middleearth.com) and [contributors](https://github.com/gandalf/unicorn/graphs/contributors).
-
-MIT License, see the included [LICENSE-MIT.md](LICENSE-MIT.md) file.
-",
-  "/package.json": "{
-  \\"name\\": \\"unicorn\\",
-  \\"repository\\": \\"gandalf/unicorn\\"
-}",
-}
-`;

--- a/packages/mrm-task-readme/index.js
+++ b/packages/mrm-task-readme/index.js
@@ -3,13 +3,14 @@ const meta = require('user-meta');
 const parseAuthor = require('parse-author');
 const packageRepoUrl = require('package-repo-url');
 const { template, packageJson } = require('mrm-core');
+const { template: smplTemplate } = require('smpltmpl');
 
 function getAuthorName(pkg) {
 	const rawName = pkg.get('author.name') || pkg.get('author') || '';
 	return parseAuthor(rawName).name;
 }
 
-function task({ packageName, name, url, readmeFile, licenseFile }) {
+function task({ packageName, name, url, readmeFile, licenseFile, license }) {
 	// Create Readme.md (no update)
 	const readme = template(
 		readmeFile,
@@ -21,7 +22,9 @@ function task({ packageName, name, url, readmeFile, licenseFile }) {
 				name,
 				url,
 				github: packageRepoUrl(),
-				license: licenseFile,
+				license: smplTemplate(licenseFile, {
+					license,
+				}),
 				package: packageName,
 			})
 			.save();
@@ -60,6 +63,12 @@ module.exports.parameters = {
 		type: 'input',
 		message: 'Enter filename for the readme',
 		default: 'Readme.md',
+	},
+	license: {
+		type: 'input',
+		message: 'Choose a license',
+		default: () => packageJson().get('license', 'MIT'),
+		choices: ['Apache-2.0', 'BSD-2-Clause', 'BSD-3-Clause', 'MIT', 'Unlicense'],
 	},
 	licenseFile: {
 		type: 'input',

--- a/packages/mrm-task-readme/index.spec.js
+++ b/packages/mrm-task-readme/index.spec.js
@@ -58,7 +58,7 @@ it('should add a readme with custom file name', async () => {
 		})
 	);
 
-	expect(
-		omitBy(vol.toJSON(), (v, k) => k.startsWith(__dirname))
-	).toMatchSnapshot();
+	expect(vol.toJSON()['/Readme.md']).toMatch(
+		'[LICENSE-MIT.md](LICENSE-MIT.md)'
+	);
 });

--- a/packages/mrm-task-readme/index.spec.js
+++ b/packages/mrm-task-readme/index.spec.js
@@ -37,3 +37,28 @@ it('should add a readme', async () => {
 		omitBy(vol.toJSON(), (v, k) => k.startsWith(__dirname))
 	).toMatchSnapshot();
 });
+
+it('should add a readme with custom file name', async () => {
+	vol.fromJSON({
+		[`${__dirname}/templates/Readme.md`]: fs
+			.readFileSync(path.join(__dirname, 'templates/Readme.md'))
+			.toString(),
+		'/package.json': stringify({
+			name: 'unicorn',
+			repository: 'gandalf/unicorn',
+		}),
+	});
+
+	task(
+		await getTaskOptions(task, false, {
+			name: 'Gandalf',
+			url: 'https://middleearth.com',
+			license: 'MIT',
+			licenseFile: "${('license-' + license).toUpperCase()}.md",
+		})
+	);
+
+	expect(
+		omitBy(vol.toJSON(), (v, k) => k.startsWith(__dirname))
+	).toMatchSnapshot();
+});

--- a/packages/mrm-task-readme/package.json
+++ b/packages/mrm-task-readme/package.json
@@ -28,6 +28,7 @@
     "mrm-core": "^4.5.0",
     "package-repo-url": "^1.0.3",
     "parse-author": "^2.0.0",
+    "smpltmpl": "^1.0.2",
     "user-meta": "^1.0.0"
   }
 }


### PR DESCRIPTION
This allows `licenseFile` to be template-based with a dynamic `${license}` portion, and adds the same to the `readme` task for parity. Will only be used if user uses template with `${license}`. Allow for preserving a file name style, e.g., `LICENSE-MIT.md` without hard-coding the license in, and allowing the license to more easily be swapped out so as to impact the name also.

And as with #123, let me know if you want `smpltmpl` reexported from mrm-core.