### PR TITLE
Task npm init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2583,30 +2583,15 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.11.0"
+        "type-fest": "^0.8.1"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -4258,8 +4243,7 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
       "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-      "dev": true,
-      "hasInstallScript": true
+      "dev": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -5541,18 +5525,15 @@
       "dev": true
     },
     "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5750,7 +5731,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -6821,7 +6801,6 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-3.1.0.tgz",
       "integrity": "sha512-FJkPoHHB+6s4a+jwPqBudBDvYZsoQW5/HBuMSehC8qDiCe50kpcxeqFoDSlow+9I6wg47YxBoT3WxaURlrDIIQ==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "chalk": "^2.4.2",
         "ci-info": "^2.0.0",
@@ -11662,10 +11641,13 @@
       }
     },
     "node_modules/run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
+      "dependencies": {
+        "is-promise": "^2.1.0"
+      },
       "engines": {
         "node": ">=0.12.0"
       }
@@ -11698,9 +11680,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
@@ -16219,20 +16201,12 @@
       }
     },
     "ansi-escapes": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+      "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.11.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
-          "dev": true
-        }
+        "type-fest": "^0.8.1"
       }
     },
     "ansi-regex": {
@@ -18660,9 +18634,9 @@
       "dev": true
     },
     "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -23588,10 +23562,13 @@
       "dev": true
     },
     "run-async": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
     },
     "run-node": {
       "version": "1.0.0",
@@ -23615,9 +23592,9 @@
       }
     },
     "rxjs": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
-      "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/packages/mrm-core/package-lock.json
+++ b/packages/mrm-core/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "babel-code-frame": "^6.26.0",

--- a/packages/mrm-core/package-lock.json
+++ b/packages/mrm-core/package-lock.json
@@ -19,6 +19,7 @@
         "lodash": "^4.17.15",
         "minimist": "^1.2.0",
         "prop-ini": "^0.0.2",
+        "rc": "^1.2.8",
         "readme-badger": "^0.3.0",
         "semver": "^6.3.0",
         "smpltmpl": "^1.0.2",
@@ -111,6 +112,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/detect-indent": {
       "version": "6.0.0",
@@ -238,6 +247,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -326,6 +340,20 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/readme-badger": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/readme-badger/-/readme-badger-0.3.0.tgz",
@@ -391,6 +419,14 @@
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/supports-color": {
@@ -510,6 +546,11 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
     "detect-indent": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
@@ -606,6 +647,11 @@
       "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
       "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
     },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -676,6 +722,17 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
     "readme-badger": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/readme-badger/-/readme-badger-0.3.0.tgz",
@@ -724,6 +781,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "2.0.0",

--- a/packages/mrm-core/package.json
+++ b/packages/mrm-core/package.json
@@ -30,6 +30,7 @@
     "lodash": "^4.17.15",
     "minimist": "^1.2.0",
     "prop-ini": "^0.0.2",
+    "rc": "^1.2.8",
     "readme-badger": "^0.3.0",
     "semver": "^6.3.0",
     "smpltmpl": "^1.0.2",

--- a/packages/mrm-core/src/index.js
+++ b/packages/mrm-core/src/index.js
@@ -19,6 +19,7 @@ module.exports = {
 	copyFiles: fs.copyFiles,
 	deleteFiles: fs.deleteFiles,
 	makeDirs: fs.makeDirs,
+	init: npm.init,
 	install: npm.install,
 	uninstall: npm.uninstall,
 	inferStyle: editorconfig.inferStyle,

--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -266,7 +266,7 @@ function getUnsatisfiedDeps(deps, versions, options) {
 	});
 }
 
-function init() {
+function config() {
 	const npm = rc('npm', null, []);
 	return {
 		version: npm['init-version'],
@@ -289,7 +289,7 @@ function isUsingYarnBerry() {
 }
 
 module.exports = {
-	init,
+	config,
 	install,
 	uninstall,
 };

--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -1,7 +1,6 @@
 // @ts-check
 const fs = require('fs-extra');
 const _ = require('lodash');
-const rc = require('rc');
 const semver = require('semver');
 const listify = require('listify');
 const validateNpmPackageName = require('validate-npm-package-name');
@@ -266,14 +265,6 @@ function getUnsatisfiedDeps(deps, versions, options) {
 	});
 }
 
-function config() {
-	const npm = rc('npm', null, []);
-	return {
-		version: npm['init-version'],
-		license: npm['init-license'],
-	};
-}
-
 /*
  * Is project using Yarn?
  */
@@ -289,7 +280,6 @@ function isUsingYarnBerry() {
 }
 
 module.exports = {
-	config,
 	install,
 	uninstall,
 };

--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -1,6 +1,7 @@
 // @ts-check
 const fs = require('fs-extra');
 const _ = require('lodash');
+const rc = require('rc');
 const semver = require('semver');
 const listify = require('listify');
 const validateNpmPackageName = require('validate-npm-package-name');
@@ -265,6 +266,14 @@ function getUnsatisfiedDeps(deps, versions, options) {
 	});
 }
 
+function init() {
+	const npm = rc('npm', null, []);
+	return {
+		version: npm['init-version'],
+		license: npm['init-license'],
+	};
+}
+
 /*
  * Is project using Yarn?
  */
@@ -280,6 +289,7 @@ function isUsingYarnBerry() {
 }
 
 module.exports = {
+	init,
 	install,
 	uninstall,
 };

--- a/packages/mrm-preset-default/package-lock.json
+++ b/packages/mrm-preset-default/package-lock.json
@@ -5,28 +5,28 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.3.7",
+      "version": "2.3.9",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0",
-        "mrm-task-ci": "^0.2.3",
-        "mrm-task-codecov": "^3.0.2",
-        "mrm-task-contributing": "^2.0.15",
-        "mrm-task-dependabot": "^1.2.5",
-        "mrm-task-editorconfig": "^2.0.16",
-        "mrm-task-eslint": "^2.0.15",
-        "mrm-task-gitignore": "^2.0.14",
-        "mrm-task-jest": "^2.0.13",
-        "mrm-task-license": "^3.1.4",
-        "mrm-task-lint-staged": "^3.0.13",
-        "mrm-task-package": "^2.1.7",
-        "mrm-task-prettier": "^3.1.2",
-        "mrm-task-readme": "^2.1.3",
-        "mrm-task-semantic-release": "^4.0.3",
-        "mrm-task-styleguidist": "^2.0.13",
-        "mrm-task-stylelint": "^3.0.14",
-        "mrm-task-travis": "^2.1.2",
-        "mrm-task-typescript": "^2.0.13"
+        "mrm-core": "^4.6.0",
+        "mrm-task-ci": "^0.2.4",
+        "mrm-task-codecov": "^3.0.3",
+        "mrm-task-contributing": "^2.0.16",
+        "mrm-task-dependabot": "^1.2.6",
+        "mrm-task-editorconfig": "^2.0.17",
+        "mrm-task-eslint": "^2.0.16",
+        "mrm-task-gitignore": "^2.0.15",
+        "mrm-task-jest": "^2.0.14",
+        "mrm-task-license": "^3.3.0",
+        "mrm-task-lint-staged": "^3.0.14",
+        "mrm-task-package": "^2.1.8",
+        "mrm-task-prettier": "^3.1.3",
+        "mrm-task-readme": "^2.3.0",
+        "mrm-task-semantic-release": "^4.0.4",
+        "mrm-task-styleguidist": "^2.0.14",
+        "mrm-task-stylelint": "^3.0.15",
+        "mrm-task-travis": "^2.1.3",
+        "mrm-task-typescript": "^2.0.14"
       },
       "engines": {
         "node": ">=8.9"
@@ -590,9 +590,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -619,14 +619,14 @@
       }
     },
     "node_modules/mrm-task-ci": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.3.tgz",
-      "integrity": "sha512-Wv8+zxAWiYAatsocT8bl9N1syVfwZekOj0JJOwi/Dl32vzoKJI2mS/f2w1nqzObn1dusKJUdHr/snk92/+M5Og==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.4.tgz",
+      "integrity": "sha512-084WkoaKIWzIzzHTRoIoewlPn/UKdOT5iirawWoqzXDD96fCDaqtyWsEyOJripIZyGDPusMIULTIN8gbgL4AWA==",
       "dependencies": {
         "git-default-branch": "^1.0.0",
         "got": "^11.8.0",
         "lodash": "^4.17.20",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       },
@@ -635,12 +635,12 @@
       }
     },
     "node_modules/mrm-task-codecov": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.2.tgz",
-      "integrity": "sha512-rjMOWPxacYc8kEbWLhOJ5u3b30GtgT+rQNlN2MiIEKldaSHAsE4QIyXxy4Fzblc9E2FAVAWYzIBK0gyfN/yFWQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.3.tgz",
+      "integrity": "sha512-u2ABw/p8qHjKQa62gUTFcV1RfDXYcanUhIpvyN6tuTnTdnWc+avp8y1rgt36JhtJS1bZzE05mVksFi/MeFRTFQ==",
       "dependencies": {
         "git-default-branch": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       },
       "engines": {
@@ -648,80 +648,81 @@
       }
     },
     "node_modules/mrm-task-contributing": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.15.tgz",
-      "integrity": "sha512-H1orUXi82IgmsaE1whQAcLZffGwskNW2VyIb9LuX8DYMaR+QnFc6CRSAPeT5z4pTfjy07YDCoHd7XlzcrU7MZw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.16.tgz",
+      "integrity": "sha512-JTfFbxyUhEWaZ4eVZEmPhG3a2oUIMXJiu4vg5gaWtuZumR5wMSwlKgRQxdD+L2VAEvdosxuFIw71bYF4khH/AA==",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-dependabot": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.5.tgz",
-      "integrity": "sha512-M9uupZyG7ahxNzASvpDVNrSzSqbcuGWC4mcFJhobAon+H+splC34yX4W5ABKkZtdFyALq5RHgWMAqv5JWEUXIg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.6.tgz",
+      "integrity": "sha512-NeJgFE7YH8eqVZW3qmCTo8UAAky6RNvdlGsLVPf9DLwDiLR9lE5te5RLQVFrkNw9mrzR/8aRCeEg/amK5V15/w==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-editorconfig": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.16.tgz",
-      "integrity": "sha512-NyhMEkziRXdQNO+etwyT6DPHlLaoF/YuZQ3Trfk1i9bReJgpk+j42V+8y0Y7v1XJ5IJPenEg3UOV6zYR4OexHg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.17.tgz",
+      "integrity": "sha512-zcOmQtedYC4wLJYF9F3jZRL5w5t0xSq3Y7q0nFhezYrzA1+929d+Bh13X1YhLJWwmOD/+RBOhuP/cCXXQrg2fw==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-eslint": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.15.tgz",
-      "integrity": "sha512-n6CHV/ITYHzBMmlRzLfN7My5/ee2DOIHzMJEiqEVklbdOKljRbrDH9y3CnrYnVxNfCAIx7+EBDAFIWWfte5EtQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.16.tgz",
+      "integrity": "sha512-khBuMpPZWYwb5xqIW39MaoCaQtzUEJvVppDnO05mM4Mxd296dAvoj/LZaPJ1mxKDHVZrl2WjcGYSwC6KWLsRPA==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-gitignore": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.14.tgz",
-      "integrity": "sha512-Hg6gSkua3MngZGruG9qj+/lphwWw3bK896ofZWw65KBhQ+p2rwkGdx5hj/NaQCCOvBxjjnIrckk4MPgtd2e4IA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.15.tgz",
+      "integrity": "sha512-qEgYk7j8EuPT/svMwLBITGRRfid3x+Axjv/i884pXQuNc5BwYmk2P68IJYqitex78ULuqX1/OBqFiMYoeWsTZQ==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-jest": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.13.tgz",
-      "integrity": "sha512-ihQi5xyjIcrNEbHKKbF/w/micWaold0rmdLoQdbWhI3B8S6hOEBQFqoimaIi5N2vN9g+a/qN/HWU4+fWyeDvhg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.14.tgz",
+      "integrity": "sha512-igwFWhHenBozA29SN84hUThtCUC8DvtmOcTUJCDAVitKl0yQoHuYCGpRmUjhkLfen9uystEvHU1+RtY2QpXUBw==",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-license": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.1.4.tgz",
-      "integrity": "sha512-7Fq7UG253Ys3xygA7YmpUzUa/e/2uzVwdTghG2YcZeVqp1l8tzDKtBdTh0QY+IHQSWxT8uJpzpBvBwHMZHefBA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.3.0.tgz",
+      "integrity": "sha512-WPkQGaLd0IEIoQUrqcR5Og6u7LkF2CqWtAzlLE/uyTP4U0NF2nuWl+FYpMPdv0rmX2/kSPvwQSR6Ks1CJhoENg==",
       "dependencies": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       },
       "engines": {
@@ -729,24 +730,24 @@
       }
     },
     "node_modules/mrm-task-lint-staged": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.13.tgz",
-      "integrity": "sha512-qlY6Cw/CtAx0G3Uz9LQjWi7j2FSBT0+NWTTsF7xEbBkIoY8bsxhIiPPpVZaxuALCGn6GxhY/qblNXn0fzvj+0g==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.14.tgz",
+      "integrity": "sha512-9MPgEdnV0EJnhGfOLkSqYf3oKfqQ9uY7JlE9tt1vNaSaxHg5M07xReGNzyFZVz+lBkJuJ5CHIq53idX2d++iUQ==",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-package": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.7.tgz",
-      "integrity": "sha512-pXdoo0u8BiRNyNFgw6uOoT+bwNgHHh6pWjRo6JxAfaZeDRBwbCml3cJmch8cqrOhglMnO6HPuhQTWxy4ebXDfg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.8.tgz",
+      "integrity": "sha512-zDeqkMZgtzJkIufwHW10VEdDh58ywfyOs7pfmBigO6FsCRa/MnjCAKGANoztuQ5/AcZwr/3CTUcFGgYVTZVXAg==",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "user-meta": "^1.0.0"
       },
       "engines": {
@@ -754,27 +755,28 @@
       }
     },
     "node_modules/mrm-task-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.2.tgz",
-      "integrity": "sha512-1U9atx7+XGGPoZcoNQbS1ZdinL8Jzkc5n3dYN5yq7NkbTimmXhUmDiYHPKPr0s0AL1RCcJRwVGIRRJ+rxL9BMw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.3.tgz",
+      "integrity": "sha512-ivpvnqNYz4IjwsagyDl0c1RVCWm0gzSn+6tN7mzM21cykYwiAEG+I9WNtvtdCNC1RpQHqWM8Eet13dPjmRoY2g==",
       "dependencies": {
         "editorconfig-to-prettier": "0.1.1",
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-readme": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.1.3.tgz",
-      "integrity": "sha512-8IsCXEr9dju1DINHCW5FFz2lHZ1je0+OIf70n9K0WDVHpmxlI0KynrDwrcSTNyIsv1BwIq82uBmRboD94cjJmA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.3.0.tgz",
+      "integrity": "sha512-NB5vSp36zb7fdzAFcZnZCqD2oR4lIE4tKqnRxlgrbQEsCR8ZIT715oLywh6UVGVTuAGontqWP3mAQd0SvGzWlQ==",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       },
       "engines": {
@@ -782,11 +784,11 @@
       }
     },
     "node_modules/mrm-task-semantic-release": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.3.tgz",
-      "integrity": "sha512-PU14NAe/fGOH/CeEbdLuxCoRq/x0FappM00QCV6MSU0qDBE6qh3VlHRSx4nKjPfrM/uehfumyLZaXpxZMg4EZg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.4.tgz",
+      "integrity": "sha512-DbaWZnvGjtKOArqo65xwPKniPOehJs1RD0U2e7oy6kL1Amc8SZqaW6FJOc4geonvXWftsJ9RS3dJ5la12SLSQA==",
       "dependencies": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       },
       "engines": {
@@ -794,34 +796,34 @@
       }
     },
     "node_modules/mrm-task-styleguidist": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.13.tgz",
-      "integrity": "sha512-K637ZjrnraK7Whhw8YHUqPFOfwvidXAr+i6ujWrdBY/MxYMVZ1wsnCKViuKf/cPtWd2AE1h9+wmLGSnnuiwPxQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.14.tgz",
+      "integrity": "sha512-zlOgbI8BClJADJPkQg84XtjO21RbkZ/JhEdBWvTXc1ZeE+8BCUWy3t8AoGOXdCwPTLMsGKQ5cKhdiviLQTUpTA==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-stylelint": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.14.tgz",
-      "integrity": "sha512-oRgZ1yMmhJvq40PL2476Q5cYbKvcvygA/vLDFu5/iRc3SJzQxTqFn7CBnkjsQpgNf4XxUglX8udckiTZcBkI4Q==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.15.tgz",
+      "integrity": "sha512-eb954TqpODdACWQF7AUyq8NfD3Qv+r+1IBl5EXCT+xkiMnQq7vtknYSA9JiHwORaxa/w6MLLXrWVfZcz+WqioQ==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-travis": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.2.tgz",
-      "integrity": "sha512-8mi/PccKokyYktI8UTQywEMvShlbLVtL04B3qTbp9fBgMQZ9ya4BzESeH0O/57pTbcvm8/3m0db7bkyf3g8TOQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.3.tgz",
+      "integrity": "sha512-axsRBsOkomIOeIFhsCysGTWFdRTMfRNfG2VhoZ6cF18e2kBttvnJm53V9Sp/upFdKHti3a1c3SU8FVjdIsf6TQ==",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       },
@@ -830,11 +832,11 @@
       }
     },
     "node_modules/mrm-task-typescript": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.13.tgz",
-      "integrity": "sha512-jNRuMQd1uaidfcliMDuR8B30n1pMhCtyfzeRR310jf9b8Ie2cFcnr6pQ/v9xhu0RS0xZRO95rDZEUuFYnBADUA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.14.tgz",
+      "integrity": "sha512-y+gSkgvMHeoy7LrzGs3BZpLYt7vKkmrLFwJmDWhrFSMgE1dUU2ylJCdUkMV7/KrpvSXlPgYLDUJ7BVlCmx+oZg==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -1603,9 +1605,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -1629,171 +1631,173 @@
       }
     },
     "mrm-task-ci": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.3.tgz",
-      "integrity": "sha512-Wv8+zxAWiYAatsocT8bl9N1syVfwZekOj0JJOwi/Dl32vzoKJI2mS/f2w1nqzObn1dusKJUdHr/snk92/+M5Og==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.4.tgz",
+      "integrity": "sha512-084WkoaKIWzIzzHTRoIoewlPn/UKdOT5iirawWoqzXDD96fCDaqtyWsEyOJripIZyGDPusMIULTIN8gbgL4AWA==",
       "requires": {
         "git-default-branch": "^1.0.0",
         "got": "^11.8.0",
         "lodash": "^4.17.20",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       }
     },
     "mrm-task-codecov": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.2.tgz",
-      "integrity": "sha512-rjMOWPxacYc8kEbWLhOJ5u3b30GtgT+rQNlN2MiIEKldaSHAsE4QIyXxy4Fzblc9E2FAVAWYzIBK0gyfN/yFWQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.3.tgz",
+      "integrity": "sha512-u2ABw/p8qHjKQa62gUTFcV1RfDXYcanUhIpvyN6tuTnTdnWc+avp8y1rgt36JhtJS1bZzE05mVksFi/MeFRTFQ==",
       "requires": {
         "git-default-branch": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       }
     },
     "mrm-task-contributing": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.15.tgz",
-      "integrity": "sha512-H1orUXi82IgmsaE1whQAcLZffGwskNW2VyIb9LuX8DYMaR+QnFc6CRSAPeT5z4pTfjy07YDCoHd7XlzcrU7MZw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.16.tgz",
+      "integrity": "sha512-JTfFbxyUhEWaZ4eVZEmPhG3a2oUIMXJiu4vg5gaWtuZumR5wMSwlKgRQxdD+L2VAEvdosxuFIw71bYF4khH/AA==",
       "requires": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-dependabot": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.5.tgz",
-      "integrity": "sha512-M9uupZyG7ahxNzASvpDVNrSzSqbcuGWC4mcFJhobAon+H+splC34yX4W5ABKkZtdFyALq5RHgWMAqv5JWEUXIg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.6.tgz",
+      "integrity": "sha512-NeJgFE7YH8eqVZW3qmCTo8UAAky6RNvdlGsLVPf9DLwDiLR9lE5te5RLQVFrkNw9mrzR/8aRCeEg/amK5V15/w==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-editorconfig": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.16.tgz",
-      "integrity": "sha512-NyhMEkziRXdQNO+etwyT6DPHlLaoF/YuZQ3Trfk1i9bReJgpk+j42V+8y0Y7v1XJ5IJPenEg3UOV6zYR4OexHg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.17.tgz",
+      "integrity": "sha512-zcOmQtedYC4wLJYF9F3jZRL5w5t0xSq3Y7q0nFhezYrzA1+929d+Bh13X1YhLJWwmOD/+RBOhuP/cCXXQrg2fw==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-eslint": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.15.tgz",
-      "integrity": "sha512-n6CHV/ITYHzBMmlRzLfN7My5/ee2DOIHzMJEiqEVklbdOKljRbrDH9y3CnrYnVxNfCAIx7+EBDAFIWWfte5EtQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.16.tgz",
+      "integrity": "sha512-khBuMpPZWYwb5xqIW39MaoCaQtzUEJvVppDnO05mM4Mxd296dAvoj/LZaPJ1mxKDHVZrl2WjcGYSwC6KWLsRPA==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-gitignore": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.14.tgz",
-      "integrity": "sha512-Hg6gSkua3MngZGruG9qj+/lphwWw3bK896ofZWw65KBhQ+p2rwkGdx5hj/NaQCCOvBxjjnIrckk4MPgtd2e4IA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.15.tgz",
+      "integrity": "sha512-qEgYk7j8EuPT/svMwLBITGRRfid3x+Axjv/i884pXQuNc5BwYmk2P68IJYqitex78ULuqX1/OBqFiMYoeWsTZQ==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-jest": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.13.tgz",
-      "integrity": "sha512-ihQi5xyjIcrNEbHKKbF/w/micWaold0rmdLoQdbWhI3B8S6hOEBQFqoimaIi5N2vN9g+a/qN/HWU4+fWyeDvhg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.14.tgz",
+      "integrity": "sha512-igwFWhHenBozA29SN84hUThtCUC8DvtmOcTUJCDAVitKl0yQoHuYCGpRmUjhkLfen9uystEvHU1+RtY2QpXUBw==",
       "requires": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-license": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.1.4.tgz",
-      "integrity": "sha512-7Fq7UG253Ys3xygA7YmpUzUa/e/2uzVwdTghG2YcZeVqp1l8tzDKtBdTh0QY+IHQSWxT8uJpzpBvBwHMZHefBA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.3.0.tgz",
+      "integrity": "sha512-WPkQGaLd0IEIoQUrqcR5Og6u7LkF2CqWtAzlLE/uyTP4U0NF2nuWl+FYpMPdv0rmX2/kSPvwQSR6Ks1CJhoENg==",
       "requires": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       }
     },
     "mrm-task-lint-staged": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.13.tgz",
-      "integrity": "sha512-qlY6Cw/CtAx0G3Uz9LQjWi7j2FSBT0+NWTTsF7xEbBkIoY8bsxhIiPPpVZaxuALCGn6GxhY/qblNXn0fzvj+0g==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.14.tgz",
+      "integrity": "sha512-9MPgEdnV0EJnhGfOLkSqYf3oKfqQ9uY7JlE9tt1vNaSaxHg5M07xReGNzyFZVz+lBkJuJ5CHIq53idX2d++iUQ==",
       "requires": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-package": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.7.tgz",
-      "integrity": "sha512-pXdoo0u8BiRNyNFgw6uOoT+bwNgHHh6pWjRo6JxAfaZeDRBwbCml3cJmch8cqrOhglMnO6HPuhQTWxy4ebXDfg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.8.tgz",
+      "integrity": "sha512-zDeqkMZgtzJkIufwHW10VEdDh58ywfyOs7pfmBigO6FsCRa/MnjCAKGANoztuQ5/AcZwr/3CTUcFGgYVTZVXAg==",
       "requires": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "user-meta": "^1.0.0"
       }
     },
     "mrm-task-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.2.tgz",
-      "integrity": "sha512-1U9atx7+XGGPoZcoNQbS1ZdinL8Jzkc5n3dYN5yq7NkbTimmXhUmDiYHPKPr0s0AL1RCcJRwVGIRRJ+rxL9BMw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.3.tgz",
+      "integrity": "sha512-ivpvnqNYz4IjwsagyDl0c1RVCWm0gzSn+6tN7mzM21cykYwiAEG+I9WNtvtdCNC1RpQHqWM8Eet13dPjmRoY2g==",
       "requires": {
         "editorconfig-to-prettier": "0.1.1",
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-readme": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.1.3.tgz",
-      "integrity": "sha512-8IsCXEr9dju1DINHCW5FFz2lHZ1je0+OIf70n9K0WDVHpmxlI0KynrDwrcSTNyIsv1BwIq82uBmRboD94cjJmA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.3.0.tgz",
+      "integrity": "sha512-NB5vSp36zb7fdzAFcZnZCqD2oR4lIE4tKqnRxlgrbQEsCR8ZIT715oLywh6UVGVTuAGontqWP3mAQd0SvGzWlQ==",
       "requires": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       }
     },
     "mrm-task-semantic-release": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.3.tgz",
-      "integrity": "sha512-PU14NAe/fGOH/CeEbdLuxCoRq/x0FappM00QCV6MSU0qDBE6qh3VlHRSx4nKjPfrM/uehfumyLZaXpxZMg4EZg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.4.tgz",
+      "integrity": "sha512-DbaWZnvGjtKOArqo65xwPKniPOehJs1RD0U2e7oy6kL1Amc8SZqaW6FJOc4geonvXWftsJ9RS3dJ5la12SLSQA==",
       "requires": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       }
     },
     "mrm-task-styleguidist": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.13.tgz",
-      "integrity": "sha512-K637ZjrnraK7Whhw8YHUqPFOfwvidXAr+i6ujWrdBY/MxYMVZ1wsnCKViuKf/cPtWd2AE1h9+wmLGSnnuiwPxQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.14.tgz",
+      "integrity": "sha512-zlOgbI8BClJADJPkQg84XtjO21RbkZ/JhEdBWvTXc1ZeE+8BCUWy3t8AoGOXdCwPTLMsGKQ5cKhdiviLQTUpTA==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-stylelint": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.14.tgz",
-      "integrity": "sha512-oRgZ1yMmhJvq40PL2476Q5cYbKvcvygA/vLDFu5/iRc3SJzQxTqFn7CBnkjsQpgNf4XxUglX8udckiTZcBkI4Q==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.15.tgz",
+      "integrity": "sha512-eb954TqpODdACWQF7AUyq8NfD3Qv+r+1IBl5EXCT+xkiMnQq7vtknYSA9JiHwORaxa/w6MLLXrWVfZcz+WqioQ==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-travis": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.2.tgz",
-      "integrity": "sha512-8mi/PccKokyYktI8UTQywEMvShlbLVtL04B3qTbp9fBgMQZ9ya4BzESeH0O/57pTbcvm8/3m0db7bkyf3g8TOQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.3.tgz",
+      "integrity": "sha512-axsRBsOkomIOeIFhsCysGTWFdRTMfRNfG2VhoZ6cF18e2kBttvnJm53V9Sp/upFdKHti3a1c3SU8FVjdIsf6TQ==",
       "requires": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       }
     },
     "mrm-task-typescript": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.13.tgz",
-      "integrity": "sha512-jNRuMQd1uaidfcliMDuR8B30n1pMhCtyfzeRR310jf9b8Ie2cFcnr6pQ/v9xhu0RS0xZRO95rDZEUuFYnBADUA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.14.tgz",
+      "integrity": "sha512-y+gSkgvMHeoy7LrzGs3BZpLYt7vKkmrLFwJmDWhrFSMgE1dUU2ylJCdUkMV7/KrpvSXlPgYLDUJ7BVlCmx+oZg==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "normalize-url": {

--- a/packages/mrm-task-ci/package-lock.json
+++ b/packages/mrm-task-ci/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "git-default-branch": "^1.0.0",
         "got": "^11.8.0",
         "lodash": "^4.17.20",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       },
@@ -547,9 +547,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -1279,9 +1279,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-codecov/package-lock.json
+++ b/packages/mrm-task-codecov/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "git-default-branch": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       },
       "engines": {
@@ -336,9 +336,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -833,9 +833,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-contributing/package-lock.json
+++ b/packages/mrm-task-contributing/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "MIT",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -333,9 +333,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -817,9 +817,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-dependabot/package-lock.json
+++ b/packages/mrm-task-dependabot/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-editorconfig/package-lock.json
+++ b/packages/mrm-task-editorconfig/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.16",
+      "version": "2.0.17",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-eslint/package-lock.json
+++ b/packages/mrm-task-eslint/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.15",
+      "version": "2.0.16",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-gitignore/package-lock.json
+++ b/packages/mrm-task-gitignore/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.14",
+      "version": "2.0.15",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-gitter/package-lock.json
+++ b/packages/mrm-task-gitter/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-jest/package-lock.json
+++ b/packages/mrm-task-jest/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -265,9 +265,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -655,9 +655,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-license/package-lock.json
+++ b/packages/mrm-task-license/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.1.4",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "parse-author": "^2.0.0",
         "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
@@ -282,9 +282,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -728,9 +728,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-lint-staged/package-lock.json
+++ b/packages/mrm-task-lint-staged/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.13",
+      "version": "3.0.14",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -265,9 +265,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -655,9 +655,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-package/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-package/__snapshots__/index.spec.js.snap
@@ -56,34 +56,6 @@ exports[`should set custom Node.js version 1`] = `
 }"
 `;
 
-exports[`should set custom Node.js version 2`] = `
-"{
-  \\"name\\": \\"\\",
-  \\"version\\": \\"1.0.0\\",
-  \\"description\\": \\"\\",
-  \\"author\\": {
-    \\"name\\": \\"Gendalf\\",
-    \\"url\\": \\"https://middleearth.com\\"
-  },
-  \\"contributors\\": [],
-  \\"homepage\\": \\"https://github.com/gendalf/\\",
-  \\"bugs\\": \\"https://github.com/gendalf//issues\\",
-  \\"repository\\": \\"https://github.com/gendalf/\\",
-  \\"license\\": \\"MIT\\",
-  \\"engines\\": {
-    \\"node\\": \\">=9.1\\"
-  },
-  \\"main\\": \\"index.js\\",
-  \\"files\\": [
-    \\"index.js\\"
-  ],
-  \\"scripts\\": {},
-  \\"keywords\\": [],
-  \\"dependencies\\": {},
-  \\"devDependencies\\": {}
-}"
-`;
-
 exports[`should set custom license 1`] = `
 "{
   \\"name\\": \\"\\",

--- a/packages/mrm-task-package/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-package/__snapshots__/index.spec.js.snap
@@ -9,8 +9,10 @@ exports[`should add package.json 1`] = `
     \\"name\\": \\"Gendalf\\",
     \\"url\\": \\"https://middleearth.com\\"
   },
+  \\"contributors\\": [],
   \\"homepage\\": \\"https://github.com/gendalf/mrm-task-package\\",
-  \\"repository\\": \\"gendalf/mrm-task-package\\",
+  \\"bugs\\": \\"https://github.com/gendalf/mrm-task-package/issues\\",
+  \\"repository\\": \\"https://github.com/gendalf/mrm-task-package\\",
   \\"license\\": \\"MIT\\",
   \\"engines\\": {
     \\"node\\": \\">=10\\"
@@ -35,8 +37,38 @@ exports[`should set custom Node.js version 1`] = `
     \\"name\\": \\"Gendalf\\",
     \\"url\\": \\"https://middleearth.com\\"
   },
+  \\"contributors\\": [],
   \\"homepage\\": \\"https://github.com/gendalf/\\",
-  \\"repository\\": \\"gendalf/\\",
+  \\"bugs\\": \\"https://github.com/gendalf//issues\\",
+  \\"repository\\": \\"https://github.com/gendalf/\\",
+  \\"license\\": \\"MIT\\",
+  \\"engines\\": {
+    \\"node\\": \\">=9.1\\"
+  },
+  \\"main\\": \\"index.js\\",
+  \\"files\\": [
+    \\"index.js\\"
+  ],
+  \\"scripts\\": {},
+  \\"keywords\\": [],
+  \\"dependencies\\": {},
+  \\"devDependencies\\": {}
+}"
+`;
+
+exports[`should set custom Node.js version 2`] = `
+"{
+  \\"name\\": \\"\\",
+  \\"version\\": \\"1.0.0\\",
+  \\"description\\": \\"\\",
+  \\"author\\": {
+    \\"name\\": \\"Gendalf\\",
+    \\"url\\": \\"https://middleearth.com\\"
+  },
+  \\"contributors\\": [],
+  \\"homepage\\": \\"https://github.com/gendalf/\\",
+  \\"bugs\\": \\"https://github.com/gendalf//issues\\",
+  \\"repository\\": \\"https://github.com/gendalf/\\",
   \\"license\\": \\"MIT\\",
   \\"engines\\": {
     \\"node\\": \\">=9.1\\"
@@ -61,8 +93,10 @@ exports[`should set custom license 1`] = `
     \\"name\\": \\"Gendalf\\",
     \\"url\\": \\"https://middleearth.com\\"
   },
+  \\"contributors\\": [],
   \\"homepage\\": \\"https://github.com/gendalf/\\",
-  \\"repository\\": \\"gendalf/\\",
+  \\"bugs\\": \\"https://github.com/gendalf//issues\\",
+  \\"repository\\": \\"https://github.com/gendalf/\\",
   \\"license\\": \\"BSD\\",
   \\"engines\\": {
     \\"node\\": \\">=10\\"

--- a/packages/mrm-task-package/index.js
+++ b/packages/mrm-task-package/index.js
@@ -7,7 +7,7 @@ const { json } = require('mrm-core');
 const rc = require('rc');
 
 // Until may add to core
-function init() {
+function config() {
 	const npm = rc('npm', null, []);
 	return {
 		version: npm['init-version'],
@@ -94,11 +94,11 @@ module.exports.parameters = {
 	version: {
 		type: 'input',
 		message: 'Enter project version',
-		default: () => init().version || '1.0.0',
+		default: () => config().version || '1.0.0',
 	},
 	license: {
 		type: 'input',
 		message: 'Enter project license',
-		default: () => init().license || 'MIT',
+		default: () => config().license || 'MIT',
 	},
 };

--- a/packages/mrm-task-package/index.js
+++ b/packages/mrm-task-package/index.js
@@ -6,8 +6,7 @@ const { json } = require('mrm-core');
 
 const rc = require('rc');
 
-// Until may add to core
-function config() {
+function getConfig() {
 	const npm = rc('npm', null, []);
 	return {
 		version: npm['init-version'],
@@ -94,11 +93,11 @@ module.exports.parameters = {
 	version: {
 		type: 'input',
 		message: 'Enter project version',
-		default: () => config().version || '1.0.0',
+		default: () => getConfig().version || '1.0.0',
 	},
 	license: {
 		type: 'input',
 		message: 'Enter project license',
-		default: () => config().license || 'MIT',
+		default: () => getConfig().license || 'MIT',
 	},
 };

--- a/packages/mrm-task-package/index.js
+++ b/packages/mrm-task-package/index.js
@@ -4,21 +4,41 @@ const meta = require('user-meta');
 const gitUsername = require('git-username');
 const { json } = require('mrm-core');
 
-module.exports = function task({ name, url, github, minNode, license }) {
+const rc = require('rc');
+
+// Until may add to core
+function init() {
+	const npm = rc('npm', null, []);
+	return {
+		version: npm['init-version'],
+		license: npm['init-license'],
+	};
+}
+
+module.exports = function task({
+	name,
+	url,
+	github,
+	minNode,
+	license,
+	version,
+}) {
 	const packageName = path.basename(process.cwd());
 	const repository = `${github}/${packageName}`;
 
 	// Create package.json
 	const pkg = json('package.json', {
 		name: packageName,
-		version: '1.0.0',
+		version,
 		description: '',
 		author: {
 			name,
 			url,
 		},
+		contributors: [],
 		homepage: `https://github.com/${repository}`,
-		repository,
+		bugs: `https://github.com/${repository}/issues`,
+		repository: `https://github.com/${repository}`,
 		license,
 		engines: {
 			node: `>=${minNode}`,
@@ -71,9 +91,14 @@ module.exports.parameters = {
 		message: 'Enter minimum supported Node.js version',
 		default: 10,
 	},
+	version: {
+		type: 'input',
+		message: 'Enter project version',
+		default: () => init().version || '1.0.0',
+	},
 	license: {
 		type: 'input',
 		message: 'Enter project license',
-		default: 'MIT',
+		default: () => init().license || 'MIT',
 	},
 };

--- a/packages/mrm-task-package/package-lock.json
+++ b/packages/mrm-task-package/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "git-username": "^1.0.0",
         "mrm-core": "^4.6.0",
+        "rc": "^1.2.8",
         "user-meta": "^1.0.0"
       },
       "engines": {

--- a/packages/mrm-task-package/package-lock.json
+++ b/packages/mrm-task-package/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "user-meta": "^1.0.0"
       },
       "engines": {
@@ -342,9 +342,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -864,9 +864,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-package/package.json
+++ b/packages/mrm-task-package/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "git-username": "^1.0.0",
     "mrm-core": "^4.6.0",
+    "rc": "^1.2.8",
     "user-meta": "^1.0.0"
   }
 }

--- a/packages/mrm-task-prettier/package-lock.json
+++ b/packages/mrm-task-prettier/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "dependencies": {
         "editorconfig-to-prettier": "0.1.1",
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -271,9 +271,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -666,9 +666,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-readme/package-lock.json
+++ b/packages/mrm-task-readme/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.3",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "parse-author": "^2.0.0",
         "smpltmpl": "^1.0.2",
@@ -347,9 +347,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -893,9 +893,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-semantic-release/package-lock.json
+++ b/packages/mrm-task-semantic-release/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       },
       "engines": {
@@ -327,9 +327,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -819,9 +819,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-styleguidist/package-lock.json
+++ b/packages/mrm-task-styleguidist/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-stylelint/package-lock.json
+++ b/packages/mrm-task-stylelint/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.14",
+      "version": "3.0.15",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-travis/package-lock.json
+++ b/packages/mrm-task-travis/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       },
@@ -329,9 +329,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -826,9 +826,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm-task-typescript/package-lock.json
+++ b/packages/mrm-task-typescript/package-lock.json
@@ -5,10 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.13",
+      "version": "2.0.14",
       "license": "MIT",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -258,9 +258,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -645,9 +645,9 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",

--- a/packages/mrm/package-lock.json
+++ b/packages/mrm/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "2.5.16",
+      "version": "2.5.18",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.3",
@@ -19,8 +19,8 @@
         "longest": "^2.0.1",
         "middleearth-names": "^1.1.0",
         "minimist": "^1.2.0",
-        "mrm-core": "^4.5.0",
-        "mrm-preset-default": "^2.3.7",
+        "mrm-core": "^4.6.0",
+        "mrm-preset-default": "^2.3.9",
         "package-json": "6.5.0",
         "requireg": "^0.2.2",
         "semver-utils": "^1.1.4",
@@ -1218,9 +1218,9 @@
       "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
     },
     "node_modules/mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "dependencies": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -1247,43 +1247,43 @@
       }
     },
     "node_modules/mrm-preset-default": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.3.7.tgz",
-      "integrity": "sha512-KEtxbZCB2Q3k0aSoZjYILy1LBdsE+u+Rbq3lzvsL+PyA2aEsUA31CknQxthl9AMCwaZjy+9ZHBlOpyQU+xmxzQ==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.3.9.tgz",
+      "integrity": "sha512-aZl1vsBeQxT4GgCrVaWDpNYgywQLIj4tBCvzqBkdj52o3/Ya5SSZyhu5EBH0quOyXnBO+iCCSGMXQXeJPlvDhA==",
       "dependencies": {
-        "mrm-core": "^4.5.0",
-        "mrm-task-ci": "^0.2.3",
-        "mrm-task-codecov": "^3.0.2",
-        "mrm-task-contributing": "^2.0.15",
-        "mrm-task-dependabot": "^1.2.5",
-        "mrm-task-editorconfig": "^2.0.16",
-        "mrm-task-eslint": "^2.0.15",
-        "mrm-task-gitignore": "^2.0.14",
-        "mrm-task-jest": "^2.0.13",
-        "mrm-task-license": "^3.1.4",
-        "mrm-task-lint-staged": "^3.0.13",
-        "mrm-task-package": "^2.1.7",
-        "mrm-task-prettier": "^3.1.2",
-        "mrm-task-readme": "^2.1.3",
-        "mrm-task-semantic-release": "^4.0.3",
-        "mrm-task-styleguidist": "^2.0.13",
-        "mrm-task-stylelint": "^3.0.14",
-        "mrm-task-travis": "^2.1.2",
-        "mrm-task-typescript": "^2.0.13"
+        "mrm-core": "^4.6.0",
+        "mrm-task-ci": "^0.2.4",
+        "mrm-task-codecov": "^3.0.3",
+        "mrm-task-contributing": "^2.0.16",
+        "mrm-task-dependabot": "^1.2.6",
+        "mrm-task-editorconfig": "^2.0.17",
+        "mrm-task-eslint": "^2.0.16",
+        "mrm-task-gitignore": "^2.0.15",
+        "mrm-task-jest": "^2.0.14",
+        "mrm-task-license": "^3.3.0",
+        "mrm-task-lint-staged": "^3.0.14",
+        "mrm-task-package": "^2.1.8",
+        "mrm-task-prettier": "^3.1.3",
+        "mrm-task-readme": "^2.3.0",
+        "mrm-task-semantic-release": "^4.0.4",
+        "mrm-task-styleguidist": "^2.0.14",
+        "mrm-task-stylelint": "^3.0.15",
+        "mrm-task-travis": "^2.1.3",
+        "mrm-task-typescript": "^2.0.14"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-ci": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.3.tgz",
-      "integrity": "sha512-Wv8+zxAWiYAatsocT8bl9N1syVfwZekOj0JJOwi/Dl32vzoKJI2mS/f2w1nqzObn1dusKJUdHr/snk92/+M5Og==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.4.tgz",
+      "integrity": "sha512-084WkoaKIWzIzzHTRoIoewlPn/UKdOT5iirawWoqzXDD96fCDaqtyWsEyOJripIZyGDPusMIULTIN8gbgL4AWA==",
       "dependencies": {
         "git-default-branch": "^1.0.0",
         "got": "^11.8.0",
         "lodash": "^4.17.20",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       },
@@ -1439,12 +1439,12 @@
       }
     },
     "node_modules/mrm-task-codecov": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.2.tgz",
-      "integrity": "sha512-rjMOWPxacYc8kEbWLhOJ5u3b30GtgT+rQNlN2MiIEKldaSHAsE4QIyXxy4Fzblc9E2FAVAWYzIBK0gyfN/yFWQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.3.tgz",
+      "integrity": "sha512-u2ABw/p8qHjKQa62gUTFcV1RfDXYcanUhIpvyN6tuTnTdnWc+avp8y1rgt36JhtJS1bZzE05mVksFi/MeFRTFQ==",
       "dependencies": {
         "git-default-branch": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       },
       "engines": {
@@ -1452,80 +1452,81 @@
       }
     },
     "node_modules/mrm-task-contributing": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.15.tgz",
-      "integrity": "sha512-H1orUXi82IgmsaE1whQAcLZffGwskNW2VyIb9LuX8DYMaR+QnFc6CRSAPeT5z4pTfjy07YDCoHd7XlzcrU7MZw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.16.tgz",
+      "integrity": "sha512-JTfFbxyUhEWaZ4eVZEmPhG3a2oUIMXJiu4vg5gaWtuZumR5wMSwlKgRQxdD+L2VAEvdosxuFIw71bYF4khH/AA==",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-dependabot": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.5.tgz",
-      "integrity": "sha512-M9uupZyG7ahxNzASvpDVNrSzSqbcuGWC4mcFJhobAon+H+splC34yX4W5ABKkZtdFyALq5RHgWMAqv5JWEUXIg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.6.tgz",
+      "integrity": "sha512-NeJgFE7YH8eqVZW3qmCTo8UAAky6RNvdlGsLVPf9DLwDiLR9lE5te5RLQVFrkNw9mrzR/8aRCeEg/amK5V15/w==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-editorconfig": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.16.tgz",
-      "integrity": "sha512-NyhMEkziRXdQNO+etwyT6DPHlLaoF/YuZQ3Trfk1i9bReJgpk+j42V+8y0Y7v1XJ5IJPenEg3UOV6zYR4OexHg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.17.tgz",
+      "integrity": "sha512-zcOmQtedYC4wLJYF9F3jZRL5w5t0xSq3Y7q0nFhezYrzA1+929d+Bh13X1YhLJWwmOD/+RBOhuP/cCXXQrg2fw==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-eslint": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.15.tgz",
-      "integrity": "sha512-n6CHV/ITYHzBMmlRzLfN7My5/ee2DOIHzMJEiqEVklbdOKljRbrDH9y3CnrYnVxNfCAIx7+EBDAFIWWfte5EtQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.16.tgz",
+      "integrity": "sha512-khBuMpPZWYwb5xqIW39MaoCaQtzUEJvVppDnO05mM4Mxd296dAvoj/LZaPJ1mxKDHVZrl2WjcGYSwC6KWLsRPA==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-gitignore": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.14.tgz",
-      "integrity": "sha512-Hg6gSkua3MngZGruG9qj+/lphwWw3bK896ofZWw65KBhQ+p2rwkGdx5hj/NaQCCOvBxjjnIrckk4MPgtd2e4IA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.15.tgz",
+      "integrity": "sha512-qEgYk7j8EuPT/svMwLBITGRRfid3x+Axjv/i884pXQuNc5BwYmk2P68IJYqitex78ULuqX1/OBqFiMYoeWsTZQ==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-jest": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.13.tgz",
-      "integrity": "sha512-ihQi5xyjIcrNEbHKKbF/w/micWaold0rmdLoQdbWhI3B8S6hOEBQFqoimaIi5N2vN9g+a/qN/HWU4+fWyeDvhg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.14.tgz",
+      "integrity": "sha512-igwFWhHenBozA29SN84hUThtCUC8DvtmOcTUJCDAVitKl0yQoHuYCGpRmUjhkLfen9uystEvHU1+RtY2QpXUBw==",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-license": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.1.4.tgz",
-      "integrity": "sha512-7Fq7UG253Ys3xygA7YmpUzUa/e/2uzVwdTghG2YcZeVqp1l8tzDKtBdTh0QY+IHQSWxT8uJpzpBvBwHMZHefBA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.3.0.tgz",
+      "integrity": "sha512-WPkQGaLd0IEIoQUrqcR5Og6u7LkF2CqWtAzlLE/uyTP4U0NF2nuWl+FYpMPdv0rmX2/kSPvwQSR6Ks1CJhoENg==",
       "dependencies": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       },
       "engines": {
@@ -1533,24 +1534,24 @@
       }
     },
     "node_modules/mrm-task-lint-staged": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.13.tgz",
-      "integrity": "sha512-qlY6Cw/CtAx0G3Uz9LQjWi7j2FSBT0+NWTTsF7xEbBkIoY8bsxhIiPPpVZaxuALCGn6GxhY/qblNXn0fzvj+0g==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.14.tgz",
+      "integrity": "sha512-9MPgEdnV0EJnhGfOLkSqYf3oKfqQ9uY7JlE9tt1vNaSaxHg5M07xReGNzyFZVz+lBkJuJ5CHIq53idX2d++iUQ==",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-package": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.7.tgz",
-      "integrity": "sha512-pXdoo0u8BiRNyNFgw6uOoT+bwNgHHh6pWjRo6JxAfaZeDRBwbCml3cJmch8cqrOhglMnO6HPuhQTWxy4ebXDfg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.8.tgz",
+      "integrity": "sha512-zDeqkMZgtzJkIufwHW10VEdDh58ywfyOs7pfmBigO6FsCRa/MnjCAKGANoztuQ5/AcZwr/3CTUcFGgYVTZVXAg==",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "user-meta": "^1.0.0"
       },
       "engines": {
@@ -1558,27 +1559,28 @@
       }
     },
     "node_modules/mrm-task-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.2.tgz",
-      "integrity": "sha512-1U9atx7+XGGPoZcoNQbS1ZdinL8Jzkc5n3dYN5yq7NkbTimmXhUmDiYHPKPr0s0AL1RCcJRwVGIRRJ+rxL9BMw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.3.tgz",
+      "integrity": "sha512-ivpvnqNYz4IjwsagyDl0c1RVCWm0gzSn+6tN7mzM21cykYwiAEG+I9WNtvtdCNC1RpQHqWM8Eet13dPjmRoY2g==",
       "dependencies": {
         "editorconfig-to-prettier": "0.1.1",
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-readme": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.1.3.tgz",
-      "integrity": "sha512-8IsCXEr9dju1DINHCW5FFz2lHZ1je0+OIf70n9K0WDVHpmxlI0KynrDwrcSTNyIsv1BwIq82uBmRboD94cjJmA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.3.0.tgz",
+      "integrity": "sha512-NB5vSp36zb7fdzAFcZnZCqD2oR4lIE4tKqnRxlgrbQEsCR8ZIT715oLywh6UVGVTuAGontqWP3mAQd0SvGzWlQ==",
       "dependencies": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       },
       "engines": {
@@ -1586,11 +1588,11 @@
       }
     },
     "node_modules/mrm-task-semantic-release": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.3.tgz",
-      "integrity": "sha512-PU14NAe/fGOH/CeEbdLuxCoRq/x0FappM00QCV6MSU0qDBE6qh3VlHRSx4nKjPfrM/uehfumyLZaXpxZMg4EZg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.4.tgz",
+      "integrity": "sha512-DbaWZnvGjtKOArqo65xwPKniPOehJs1RD0U2e7oy6kL1Amc8SZqaW6FJOc4geonvXWftsJ9RS3dJ5la12SLSQA==",
       "dependencies": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       },
       "engines": {
@@ -1598,34 +1600,34 @@
       }
     },
     "node_modules/mrm-task-styleguidist": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.13.tgz",
-      "integrity": "sha512-K637ZjrnraK7Whhw8YHUqPFOfwvidXAr+i6ujWrdBY/MxYMVZ1wsnCKViuKf/cPtWd2AE1h9+wmLGSnnuiwPxQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.14.tgz",
+      "integrity": "sha512-zlOgbI8BClJADJPkQg84XtjO21RbkZ/JhEdBWvTXc1ZeE+8BCUWy3t8AoGOXdCwPTLMsGKQ5cKhdiviLQTUpTA==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-stylelint": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.14.tgz",
-      "integrity": "sha512-oRgZ1yMmhJvq40PL2476Q5cYbKvcvygA/vLDFu5/iRc3SJzQxTqFn7CBnkjsQpgNf4XxUglX8udckiTZcBkI4Q==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.15.tgz",
+      "integrity": "sha512-eb954TqpODdACWQF7AUyq8NfD3Qv+r+1IBl5EXCT+xkiMnQq7vtknYSA9JiHwORaxa/w6MLLXrWVfZcz+WqioQ==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
       }
     },
     "node_modules/mrm-task-travis": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.2.tgz",
-      "integrity": "sha512-8mi/PccKokyYktI8UTQywEMvShlbLVtL04B3qTbp9fBgMQZ9ya4BzESeH0O/57pTbcvm8/3m0db7bkyf3g8TOQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.3.tgz",
+      "integrity": "sha512-axsRBsOkomIOeIFhsCysGTWFdRTMfRNfG2VhoZ6cF18e2kBttvnJm53V9Sp/upFdKHti3a1c3SU8FVjdIsf6TQ==",
       "dependencies": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       },
@@ -1634,11 +1636,11 @@
       }
     },
     "node_modules/mrm-task-typescript": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.13.tgz",
-      "integrity": "sha512-jNRuMQd1uaidfcliMDuR8B30n1pMhCtyfzeRR310jf9b8Ie2cFcnr6pQ/v9xhu0RS0xZRO95rDZEUuFYnBADUA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.14.tgz",
+      "integrity": "sha512-y+gSkgvMHeoy7LrzGs3BZpLYt7vKkmrLFwJmDWhrFSMgE1dUU2ylJCdUkMV7/KrpvSXlPgYLDUJ7BVlCmx+oZg==",
       "dependencies": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       },
       "engines": {
         "node": ">=8.9"
@@ -3404,9 +3406,9 @@
       "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
     },
     "mrm-core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.5.0.tgz",
-      "integrity": "sha512-50XWS+xQko6DyJIHmfvAhZ2agK0gbUgpHQbLfXum9oP4IaICclHuXsbcFtDCyV3K/lE/g4G2GS+qMTOKZT05wg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-4.6.0.tgz",
+      "integrity": "sha512-XgDEWcMROM/SVdBKUUympJ/VwmNElKUxdMjAkZjZlpyuGAabGR6OVdS4M2jtPQcrmVVdMqaNpeJDRDd0BGoPwA==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^2.2.0",
@@ -3430,40 +3432,40 @@
       }
     },
     "mrm-preset-default": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.3.7.tgz",
-      "integrity": "sha512-KEtxbZCB2Q3k0aSoZjYILy1LBdsE+u+Rbq3lzvsL+PyA2aEsUA31CknQxthl9AMCwaZjy+9ZHBlOpyQU+xmxzQ==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.3.9.tgz",
+      "integrity": "sha512-aZl1vsBeQxT4GgCrVaWDpNYgywQLIj4tBCvzqBkdj52o3/Ya5SSZyhu5EBH0quOyXnBO+iCCSGMXQXeJPlvDhA==",
       "requires": {
-        "mrm-core": "^4.5.0",
-        "mrm-task-ci": "^0.2.3",
-        "mrm-task-codecov": "^3.0.2",
-        "mrm-task-contributing": "^2.0.15",
-        "mrm-task-dependabot": "^1.2.5",
-        "mrm-task-editorconfig": "^2.0.16",
-        "mrm-task-eslint": "^2.0.15",
-        "mrm-task-gitignore": "^2.0.14",
-        "mrm-task-jest": "^2.0.13",
-        "mrm-task-license": "^3.1.4",
-        "mrm-task-lint-staged": "^3.0.13",
-        "mrm-task-package": "^2.1.7",
-        "mrm-task-prettier": "^3.1.2",
-        "mrm-task-readme": "^2.1.3",
-        "mrm-task-semantic-release": "^4.0.3",
-        "mrm-task-styleguidist": "^2.0.13",
-        "mrm-task-stylelint": "^3.0.14",
-        "mrm-task-travis": "^2.1.2",
-        "mrm-task-typescript": "^2.0.13"
+        "mrm-core": "^4.6.0",
+        "mrm-task-ci": "^0.2.4",
+        "mrm-task-codecov": "^3.0.3",
+        "mrm-task-contributing": "^2.0.16",
+        "mrm-task-dependabot": "^1.2.6",
+        "mrm-task-editorconfig": "^2.0.17",
+        "mrm-task-eslint": "^2.0.16",
+        "mrm-task-gitignore": "^2.0.15",
+        "mrm-task-jest": "^2.0.14",
+        "mrm-task-license": "^3.3.0",
+        "mrm-task-lint-staged": "^3.0.14",
+        "mrm-task-package": "^2.1.8",
+        "mrm-task-prettier": "^3.1.3",
+        "mrm-task-readme": "^2.3.0",
+        "mrm-task-semantic-release": "^4.0.4",
+        "mrm-task-styleguidist": "^2.0.14",
+        "mrm-task-stylelint": "^3.0.15",
+        "mrm-task-travis": "^2.1.3",
+        "mrm-task-typescript": "^2.0.14"
       }
     },
     "mrm-task-ci": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.3.tgz",
-      "integrity": "sha512-Wv8+zxAWiYAatsocT8bl9N1syVfwZekOj0JJOwi/Dl32vzoKJI2mS/f2w1nqzObn1dusKJUdHr/snk92/+M5Og==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.4.tgz",
+      "integrity": "sha512-084WkoaKIWzIzzHTRoIoewlPn/UKdOT5iirawWoqzXDD96fCDaqtyWsEyOJripIZyGDPusMIULTIN8gbgL4AWA==",
       "requires": {
         "git-default-branch": "^1.0.0",
         "got": "^11.8.0",
         "lodash": "^4.17.20",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       },
@@ -3573,158 +3575,160 @@
       }
     },
     "mrm-task-codecov": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.2.tgz",
-      "integrity": "sha512-rjMOWPxacYc8kEbWLhOJ5u3b30GtgT+rQNlN2MiIEKldaSHAsE4QIyXxy4Fzblc9E2FAVAWYzIBK0gyfN/yFWQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.3.tgz",
+      "integrity": "sha512-u2ABw/p8qHjKQa62gUTFcV1RfDXYcanUhIpvyN6tuTnTdnWc+avp8y1rgt36JhtJS1bZzE05mVksFi/MeFRTFQ==",
       "requires": {
         "git-default-branch": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       }
     },
     "mrm-task-contributing": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.15.tgz",
-      "integrity": "sha512-H1orUXi82IgmsaE1whQAcLZffGwskNW2VyIb9LuX8DYMaR+QnFc6CRSAPeT5z4pTfjy07YDCoHd7XlzcrU7MZw==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.16.tgz",
+      "integrity": "sha512-JTfFbxyUhEWaZ4eVZEmPhG3a2oUIMXJiu4vg5gaWtuZumR5wMSwlKgRQxdD+L2VAEvdosxuFIw71bYF4khH/AA==",
       "requires": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-dependabot": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.5.tgz",
-      "integrity": "sha512-M9uupZyG7ahxNzASvpDVNrSzSqbcuGWC4mcFJhobAon+H+splC34yX4W5ABKkZtdFyALq5RHgWMAqv5JWEUXIg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.6.tgz",
+      "integrity": "sha512-NeJgFE7YH8eqVZW3qmCTo8UAAky6RNvdlGsLVPf9DLwDiLR9lE5te5RLQVFrkNw9mrzR/8aRCeEg/amK5V15/w==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-editorconfig": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.16.tgz",
-      "integrity": "sha512-NyhMEkziRXdQNO+etwyT6DPHlLaoF/YuZQ3Trfk1i9bReJgpk+j42V+8y0Y7v1XJ5IJPenEg3UOV6zYR4OexHg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.17.tgz",
+      "integrity": "sha512-zcOmQtedYC4wLJYF9F3jZRL5w5t0xSq3Y7q0nFhezYrzA1+929d+Bh13X1YhLJWwmOD/+RBOhuP/cCXXQrg2fw==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-eslint": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.15.tgz",
-      "integrity": "sha512-n6CHV/ITYHzBMmlRzLfN7My5/ee2DOIHzMJEiqEVklbdOKljRbrDH9y3CnrYnVxNfCAIx7+EBDAFIWWfte5EtQ==",
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.16.tgz",
+      "integrity": "sha512-khBuMpPZWYwb5xqIW39MaoCaQtzUEJvVppDnO05mM4Mxd296dAvoj/LZaPJ1mxKDHVZrl2WjcGYSwC6KWLsRPA==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-gitignore": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.14.tgz",
-      "integrity": "sha512-Hg6gSkua3MngZGruG9qj+/lphwWw3bK896ofZWw65KBhQ+p2rwkGdx5hj/NaQCCOvBxjjnIrckk4MPgtd2e4IA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.15.tgz",
+      "integrity": "sha512-qEgYk7j8EuPT/svMwLBITGRRfid3x+Axjv/i884pXQuNc5BwYmk2P68IJYqitex78ULuqX1/OBqFiMYoeWsTZQ==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-jest": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.13.tgz",
-      "integrity": "sha512-ihQi5xyjIcrNEbHKKbF/w/micWaold0rmdLoQdbWhI3B8S6hOEBQFqoimaIi5N2vN9g+a/qN/HWU4+fWyeDvhg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.14.tgz",
+      "integrity": "sha512-igwFWhHenBozA29SN84hUThtCUC8DvtmOcTUJCDAVitKl0yQoHuYCGpRmUjhkLfen9uystEvHU1+RtY2QpXUBw==",
       "requires": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-license": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.1.4.tgz",
-      "integrity": "sha512-7Fq7UG253Ys3xygA7YmpUzUa/e/2uzVwdTghG2YcZeVqp1l8tzDKtBdTh0QY+IHQSWxT8uJpzpBvBwHMZHefBA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.3.0.tgz",
+      "integrity": "sha512-WPkQGaLd0IEIoQUrqcR5Og6u7LkF2CqWtAzlLE/uyTP4U0NF2nuWl+FYpMPdv0rmX2/kSPvwQSR6Ks1CJhoENg==",
       "requires": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       }
     },
     "mrm-task-lint-staged": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.13.tgz",
-      "integrity": "sha512-qlY6Cw/CtAx0G3Uz9LQjWi7j2FSBT0+NWTTsF7xEbBkIoY8bsxhIiPPpVZaxuALCGn6GxhY/qblNXn0fzvj+0g==",
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.14.tgz",
+      "integrity": "sha512-9MPgEdnV0EJnhGfOLkSqYf3oKfqQ9uY7JlE9tt1vNaSaxHg5M07xReGNzyFZVz+lBkJuJ5CHIq53idX2d++iUQ==",
       "requires": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-package": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.7.tgz",
-      "integrity": "sha512-pXdoo0u8BiRNyNFgw6uOoT+bwNgHHh6pWjRo6JxAfaZeDRBwbCml3cJmch8cqrOhglMnO6HPuhQTWxy4ebXDfg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.8.tgz",
+      "integrity": "sha512-zDeqkMZgtzJkIufwHW10VEdDh58ywfyOs7pfmBigO6FsCRa/MnjCAKGANoztuQ5/AcZwr/3CTUcFGgYVTZVXAg==",
       "requires": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "user-meta": "^1.0.0"
       }
     },
     "mrm-task-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.2.tgz",
-      "integrity": "sha512-1U9atx7+XGGPoZcoNQbS1ZdinL8Jzkc5n3dYN5yq7NkbTimmXhUmDiYHPKPr0s0AL1RCcJRwVGIRRJ+rxL9BMw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.3.tgz",
+      "integrity": "sha512-ivpvnqNYz4IjwsagyDl0c1RVCWm0gzSn+6tN7mzM21cykYwiAEG+I9WNtvtdCNC1RpQHqWM8Eet13dPjmRoY2g==",
       "requires": {
         "editorconfig-to-prettier": "0.1.1",
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-readme": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.1.3.tgz",
-      "integrity": "sha512-8IsCXEr9dju1DINHCW5FFz2lHZ1je0+OIf70n9K0WDVHpmxlI0KynrDwrcSTNyIsv1BwIq82uBmRboD94cjJmA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.3.0.tgz",
+      "integrity": "sha512-NB5vSp36zb7fdzAFcZnZCqD2oR4lIE4tKqnRxlgrbQEsCR8ZIT715oLywh6UVGVTuAGontqWP3mAQd0SvGzWlQ==",
       "requires": {
         "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "parse-author": "^2.0.0",
+        "smpltmpl": "^1.0.2",
         "user-meta": "^1.0.0"
       }
     },
     "mrm-task-semantic-release": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.3.tgz",
-      "integrity": "sha512-PU14NAe/fGOH/CeEbdLuxCoRq/x0FappM00QCV6MSU0qDBE6qh3VlHRSx4nKjPfrM/uehfumyLZaXpxZMg4EZg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.4.tgz",
+      "integrity": "sha512-DbaWZnvGjtKOArqo65xwPKniPOehJs1RD0U2e7oy6kL1Amc8SZqaW6FJOc4geonvXWftsJ9RS3dJ5la12SLSQA==",
       "requires": {
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3"
       }
     },
     "mrm-task-styleguidist": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.13.tgz",
-      "integrity": "sha512-K637ZjrnraK7Whhw8YHUqPFOfwvidXAr+i6ujWrdBY/MxYMVZ1wsnCKViuKf/cPtWd2AE1h9+wmLGSnnuiwPxQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.14.tgz",
+      "integrity": "sha512-zlOgbI8BClJADJPkQg84XtjO21RbkZ/JhEdBWvTXc1ZeE+8BCUWy3t8AoGOXdCwPTLMsGKQ5cKhdiviLQTUpTA==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-stylelint": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.14.tgz",
-      "integrity": "sha512-oRgZ1yMmhJvq40PL2476Q5cYbKvcvygA/vLDFu5/iRc3SJzQxTqFn7CBnkjsQpgNf4XxUglX8udckiTZcBkI4Q==",
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.15.tgz",
+      "integrity": "sha512-eb954TqpODdACWQF7AUyq8NfD3Qv+r+1IBl5EXCT+xkiMnQq7vtknYSA9JiHwORaxa/w6MLLXrWVfZcz+WqioQ==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mrm-task-travis": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.2.tgz",
-      "integrity": "sha512-8mi/PccKokyYktI8UTQywEMvShlbLVtL04B3qTbp9fBgMQZ9ya4BzESeH0O/57pTbcvm8/3m0db7bkyf3g8TOQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.3.tgz",
+      "integrity": "sha512-axsRBsOkomIOeIFhsCysGTWFdRTMfRNfG2VhoZ6cF18e2kBttvnJm53V9Sp/upFdKHti3a1c3SU8FVjdIsf6TQ==",
       "requires": {
         "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0",
+        "mrm-core": "^4.6.0",
         "package-repo-url": "^1.0.3",
         "semver-utils": "^1.1.4"
       }
     },
     "mrm-task-typescript": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.13.tgz",
-      "integrity": "sha512-jNRuMQd1uaidfcliMDuR8B30n1pMhCtyfzeRR310jf9b8Ie2cFcnr6pQ/v9xhu0RS0xZRO95rDZEUuFYnBADUA==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.14.tgz",
+      "integrity": "sha512-y+gSkgvMHeoy7LrzGs3BZpLYt7vKkmrLFwJmDWhrFSMgE1dUU2ylJCdUkMV7/KrpvSXlPgYLDUJ7BVlCmx+oZg==",
       "requires": {
-        "mrm-core": "^4.5.0"
+        "mrm-core": "^4.6.0"
       }
     },
     "mute-stream": {


### PR DESCRIPTION
Builds on #129.

- feat(package): use any npm init license/version config; add `bugs`, `contributors`; full `repository` URL (easier open-clicking within IDEs)

Those extra `package.json` fields are reported by linters, and `bugs` is used on npmjs.com.

I figure that if you're ok with this, that you might want the npm init in its own package like your `user-meta` package (but since license and version are not quite related to the *user*, I didn't think they'd go there.

I also wasn't sure if there were some way around the need to make a separate mrm-core contribution to expose this API before starting using it (since it will depend on an available version bump), so I added it for now both to core and to the `package` repo.