### PR TITLE
Remove default preset from mrm package deps

### DIFF
--- a/packages/mrm/package-lock.json
+++ b/packages/mrm/package-lock.json
@@ -20,7 +20,6 @@
         "middleearth-names": "^1.1.0",
         "minimist": "^1.2.0",
         "mrm-core": "^4.5.0",
-        "mrm-preset-default": "^2.3.7",
         "semver-utils": "^1.1.4",
         "update-notifier": "^4.1.0",
         "user-home": "^2.0.0",
@@ -52,47 +51,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
-        "@types/node": "*",
-        "@types/responselike": "*"
-      }
-    },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
-    "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/ansi-align": {
       "version": "3.0.0",
@@ -151,14 +113,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/author-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
-      "integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/babel-code-frame": {
@@ -316,14 +270,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
-    },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "engines": {
-        "node": ">=10.6.0"
-      }
     },
     "node_modules/cacheable-request": {
       "version": "6.1.0",
@@ -610,11 +556,6 @@
         "editorconfig": "bin/editorconfig"
       }
     },
-    "node_modules/editorconfig-to-prettier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz",
-      "integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ=="
-    },
     "node_modules/editorconfig/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -847,14 +788,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/git-default-branch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/git-default-branch/-/git-default-branch-1.0.0.tgz",
-      "integrity": "sha512-/eBj13g+SDiPnRMO82wTCA6P0Xi413TWSeyjf5Qj/vdLzn7iXROotuElMF4fNxNlL7TMbUjUW1EHjd3E9OAItQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/git-username": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/git-username/-/git-username-1.0.0.tgz",
@@ -983,18 +916,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-    },
-    "node_modules/http2-wrapper": {
-      "version": "1.0.0-beta.5.2",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
-      "dependencies": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -1787,389 +1708,6 @@
         "node": ">=8.9"
       }
     },
-    "node_modules/mrm-preset-default": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.3.7.tgz",
-      "integrity": "sha512-KEtxbZCB2Q3k0aSoZjYILy1LBdsE+u+Rbq3lzvsL+PyA2aEsUA31CknQxthl9AMCwaZjy+9ZHBlOpyQU+xmxzQ==",
-      "dependencies": {
-        "mrm-core": "^4.5.0",
-        "mrm-task-ci": "^0.2.3",
-        "mrm-task-codecov": "^3.0.2",
-        "mrm-task-contributing": "^2.0.15",
-        "mrm-task-dependabot": "^1.2.5",
-        "mrm-task-editorconfig": "^2.0.16",
-        "mrm-task-eslint": "^2.0.15",
-        "mrm-task-gitignore": "^2.0.14",
-        "mrm-task-jest": "^2.0.13",
-        "mrm-task-license": "^3.1.4",
-        "mrm-task-lint-staged": "^3.0.13",
-        "mrm-task-package": "^2.1.7",
-        "mrm-task-prettier": "^3.1.2",
-        "mrm-task-readme": "^2.1.3",
-        "mrm-task-semantic-release": "^4.0.3",
-        "mrm-task-styleguidist": "^2.0.13",
-        "mrm-task-stylelint": "^3.0.14",
-        "mrm-task-travis": "^2.1.2",
-        "mrm-task-typescript": "^2.0.13"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-ci": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.3.tgz",
-      "integrity": "sha512-Wv8+zxAWiYAatsocT8bl9N1syVfwZekOj0JJOwi/Dl32vzoKJI2mS/f2w1nqzObn1dusKJUdHr/snk92/+M5Og==",
-      "dependencies": {
-        "git-default-branch": "^1.0.0",
-        "got": "^11.8.0",
-        "lodash": "^4.17.20",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3",
-        "semver-utils": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/@sindresorhus/is": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
-      "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/@szmarczak/http-timer": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-      "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/cacheable-request": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-      "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-      "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/defer-to-connect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-      "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/got": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-      "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
-      "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.1",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.19.0"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
-    },
-    "node_modules/mrm-task-ci/node_modules/keyv": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-      "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/p-cancelable": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-      "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/mrm-task-ci/node_modules/responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-      "dependencies": {
-        "lowercase-keys": "^2.0.0"
-      }
-    },
-    "node_modules/mrm-task-codecov": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.2.tgz",
-      "integrity": "sha512-rjMOWPxacYc8kEbWLhOJ5u3b30GtgT+rQNlN2MiIEKldaSHAsE4QIyXxy4Fzblc9E2FAVAWYzIBK0gyfN/yFWQ==",
-      "dependencies": {
-        "git-default-branch": "^1.0.0",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-contributing": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.15.tgz",
-      "integrity": "sha512-H1orUXi82IgmsaE1whQAcLZffGwskNW2VyIb9LuX8DYMaR+QnFc6CRSAPeT5z4pTfjy07YDCoHd7XlzcrU7MZw==",
-      "dependencies": {
-        "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-dependabot": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.5.tgz",
-      "integrity": "sha512-M9uupZyG7ahxNzASvpDVNrSzSqbcuGWC4mcFJhobAon+H+splC34yX4W5ABKkZtdFyALq5RHgWMAqv5JWEUXIg==",
-      "dependencies": {
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-editorconfig": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.16.tgz",
-      "integrity": "sha512-NyhMEkziRXdQNO+etwyT6DPHlLaoF/YuZQ3Trfk1i9bReJgpk+j42V+8y0Y7v1XJ5IJPenEg3UOV6zYR4OexHg==",
-      "dependencies": {
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-eslint": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.15.tgz",
-      "integrity": "sha512-n6CHV/ITYHzBMmlRzLfN7My5/ee2DOIHzMJEiqEVklbdOKljRbrDH9y3CnrYnVxNfCAIx7+EBDAFIWWfte5EtQ==",
-      "dependencies": {
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-gitignore": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.14.tgz",
-      "integrity": "sha512-Hg6gSkua3MngZGruG9qj+/lphwWw3bK896ofZWw65KBhQ+p2rwkGdx5hj/NaQCCOvBxjjnIrckk4MPgtd2e4IA==",
-      "dependencies": {
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-jest": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.13.tgz",
-      "integrity": "sha512-ihQi5xyjIcrNEbHKKbF/w/micWaold0rmdLoQdbWhI3B8S6hOEBQFqoimaIi5N2vN9g+a/qN/HWU4+fWyeDvhg==",
-      "dependencies": {
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-license": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.1.4.tgz",
-      "integrity": "sha512-7Fq7UG253Ys3xygA7YmpUzUa/e/2uzVwdTghG2YcZeVqp1l8tzDKtBdTh0QY+IHQSWxT8uJpzpBvBwHMZHefBA==",
-      "dependencies": {
-        "mrm-core": "^4.5.0",
-        "parse-author": "^2.0.0",
-        "user-meta": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-lint-staged": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.13.tgz",
-      "integrity": "sha512-qlY6Cw/CtAx0G3Uz9LQjWi7j2FSBT0+NWTTsF7xEbBkIoY8bsxhIiPPpVZaxuALCGn6GxhY/qblNXn0fzvj+0g==",
-      "dependencies": {
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-package": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.7.tgz",
-      "integrity": "sha512-pXdoo0u8BiRNyNFgw6uOoT+bwNgHHh6pWjRo6JxAfaZeDRBwbCml3cJmch8cqrOhglMnO6HPuhQTWxy4ebXDfg==",
-      "dependencies": {
-        "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
-        "user-meta": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.2.tgz",
-      "integrity": "sha512-1U9atx7+XGGPoZcoNQbS1ZdinL8Jzkc5n3dYN5yq7NkbTimmXhUmDiYHPKPr0s0AL1RCcJRwVGIRRJ+rxL9BMw==",
-      "dependencies": {
-        "editorconfig-to-prettier": "0.1.1",
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-readme": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.1.3.tgz",
-      "integrity": "sha512-8IsCXEr9dju1DINHCW5FFz2lHZ1je0+OIf70n9K0WDVHpmxlI0KynrDwrcSTNyIsv1BwIq82uBmRboD94cjJmA==",
-      "dependencies": {
-        "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3",
-        "parse-author": "^2.0.0",
-        "user-meta": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-semantic-release": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.3.tgz",
-      "integrity": "sha512-PU14NAe/fGOH/CeEbdLuxCoRq/x0FappM00QCV6MSU0qDBE6qh3VlHRSx4nKjPfrM/uehfumyLZaXpxZMg4EZg==",
-      "dependencies": {
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-styleguidist": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.13.tgz",
-      "integrity": "sha512-K637ZjrnraK7Whhw8YHUqPFOfwvidXAr+i6ujWrdBY/MxYMVZ1wsnCKViuKf/cPtWd2AE1h9+wmLGSnnuiwPxQ==",
-      "dependencies": {
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-stylelint": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.14.tgz",
-      "integrity": "sha512-oRgZ1yMmhJvq40PL2476Q5cYbKvcvygA/vLDFu5/iRc3SJzQxTqFn7CBnkjsQpgNf4XxUglX8udckiTZcBkI4Q==",
-      "dependencies": {
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-travis": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.2.tgz",
-      "integrity": "sha512-8mi/PccKokyYktI8UTQywEMvShlbLVtL04B3qTbp9fBgMQZ9ya4BzESeH0O/57pTbcvm8/3m0db7bkyf3g8TOQ==",
-      "dependencies": {
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3",
-        "semver-utils": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/mrm-task-typescript": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.13.tgz",
-      "integrity": "sha512-jNRuMQd1uaidfcliMDuR8B30n1pMhCtyfzeRR310jf9b8Ie2cFcnr6pQ/v9xhu0RS0xZRO95rDZEUuFYnBADUA==",
-      "dependencies": {
-        "mrm-core": "^4.5.0"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -2325,28 +1863,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/package-repo-url": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/package-repo-url/-/package-repo-url-1.0.3.tgz",
-      "integrity": "sha512-DcoCnScztg2NJ2JmVgdJT7b7uMaYCcQFQiq6/AXv1yNwYm5EloCKXNQJOXLYKBAkJzto6SIejkHOWz4uvCfRAA==",
-      "dependencies": {
-        "git-username": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/parse-author": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
-      "integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
-      "dependencies": {
-        "author-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/parse-git-config": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
@@ -2450,14 +1966,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -2533,11 +2041,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-    },
-    "node_modules/resolve-alpn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
-      "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA=="
     },
     "node_modules/responselike": {
       "version": "1.0.2",
@@ -3170,47 +2673,10 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@types/cacheable-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
-      "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
-      "requires": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "*",
-        "@types/node": "*",
-        "@types/responselike": "*"
-      }
-    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
-    },
-    "@types/http-cache-semantics": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
-      "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A=="
-    },
-    "@types/keyv": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
-      "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
-    },
-    "@types/responselike": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -3259,11 +2725,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "author-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
-      "integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -3391,11 +2852,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
-    },
-    "cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA=="
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -3633,11 +3089,6 @@
         }
       }
     },
-    "editorconfig-to-prettier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz",
-      "integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ=="
-    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -3806,11 +3257,6 @@
         "homedir-polyfill": "^1.0.0"
       }
     },
-    "git-default-branch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/git-default-branch/-/git-default-branch-1.0.0.tgz",
-      "integrity": "sha512-/eBj13g+SDiPnRMO82wTCA6P0Xi413TWSeyjf5Qj/vdLzn7iXROotuElMF4fNxNlL7TMbUjUW1EHjd3E9OAItQ=="
-    },
     "git-username": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/git-username/-/git-username-1.0.0.tgz",
@@ -3911,15 +3357,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
-    },
-    "http2-wrapper": {
-      "version": "1.0.0-beta.5.2",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
-      "requires": {
-        "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
-      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -4535,304 +3972,6 @@
         "yaml": "^2.0.0-1"
       }
     },
-    "mrm-preset-default": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/mrm-preset-default/-/mrm-preset-default-2.3.7.tgz",
-      "integrity": "sha512-KEtxbZCB2Q3k0aSoZjYILy1LBdsE+u+Rbq3lzvsL+PyA2aEsUA31CknQxthl9AMCwaZjy+9ZHBlOpyQU+xmxzQ==",
-      "requires": {
-        "mrm-core": "^4.5.0",
-        "mrm-task-ci": "^0.2.3",
-        "mrm-task-codecov": "^3.0.2",
-        "mrm-task-contributing": "^2.0.15",
-        "mrm-task-dependabot": "^1.2.5",
-        "mrm-task-editorconfig": "^2.0.16",
-        "mrm-task-eslint": "^2.0.15",
-        "mrm-task-gitignore": "^2.0.14",
-        "mrm-task-jest": "^2.0.13",
-        "mrm-task-license": "^3.1.4",
-        "mrm-task-lint-staged": "^3.0.13",
-        "mrm-task-package": "^2.1.7",
-        "mrm-task-prettier": "^3.1.2",
-        "mrm-task-readme": "^2.1.3",
-        "mrm-task-semantic-release": "^4.0.3",
-        "mrm-task-styleguidist": "^2.0.13",
-        "mrm-task-stylelint": "^3.0.14",
-        "mrm-task-travis": "^2.1.2",
-        "mrm-task-typescript": "^2.0.13"
-      }
-    },
-    "mrm-task-ci": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-ci/-/mrm-task-ci-0.2.3.tgz",
-      "integrity": "sha512-Wv8+zxAWiYAatsocT8bl9N1syVfwZekOj0JJOwi/Dl32vzoKJI2mS/f2w1nqzObn1dusKJUdHr/snk92/+M5Og==",
-      "requires": {
-        "git-default-branch": "^1.0.0",
-        "got": "^11.8.0",
-        "lodash": "^4.17.20",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3",
-        "semver-utils": "^1.1.4"
-      },
-      "dependencies": {
-        "@sindresorhus/is": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
-          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ=="
-        },
-        "@szmarczak/http-timer": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-          "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-          "requires": {
-            "defer-to-connect": "^2.0.0"
-          }
-        },
-        "cacheable-request": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-          "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-          "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^4.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "decompress-response": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-          "requires": {
-            "mimic-response": "^3.1.0"
-          }
-        },
-        "defer-to-connect": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg=="
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "got": {
-          "version": "11.8.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-          "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
-          "requires": {
-            "@sindresorhus/is": "^4.0.0",
-            "@szmarczak/http-timer": "^4.0.5",
-            "@types/cacheable-request": "^6.0.1",
-            "@types/responselike": "^1.0.0",
-            "cacheable-lookup": "^5.0.3",
-            "cacheable-request": "^7.0.1",
-            "decompress-response": "^6.0.0",
-            "http2-wrapper": "^1.0.0-beta.5.2",
-            "lowercase-keys": "^2.0.0",
-            "p-cancelable": "^2.0.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "json-buffer": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
-        },
-        "keyv": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
-          "requires": {
-            "json-buffer": "3.0.1"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
-        },
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
-        },
-        "p-cancelable": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg=="
-        },
-        "responselike": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-          "requires": {
-            "lowercase-keys": "^2.0.0"
-          }
-        }
-      }
-    },
-    "mrm-task-codecov": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-codecov/-/mrm-task-codecov-3.0.2.tgz",
-      "integrity": "sha512-rjMOWPxacYc8kEbWLhOJ5u3b30GtgT+rQNlN2MiIEKldaSHAsE4QIyXxy4Fzblc9E2FAVAWYzIBK0gyfN/yFWQ==",
-      "requires": {
-        "git-default-branch": "^1.0.0",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3"
-      }
-    },
-    "mrm-task-contributing": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-contributing/-/mrm-task-contributing-2.0.15.tgz",
-      "integrity": "sha512-H1orUXi82IgmsaE1whQAcLZffGwskNW2VyIb9LuX8DYMaR+QnFc6CRSAPeT5z4pTfjy07YDCoHd7XlzcrU7MZw==",
-      "requires": {
-        "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-dependabot": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/mrm-task-dependabot/-/mrm-task-dependabot-1.2.5.tgz",
-      "integrity": "sha512-M9uupZyG7ahxNzASvpDVNrSzSqbcuGWC4mcFJhobAon+H+splC34yX4W5ABKkZtdFyALq5RHgWMAqv5JWEUXIg==",
-      "requires": {
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-editorconfig": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/mrm-task-editorconfig/-/mrm-task-editorconfig-2.0.16.tgz",
-      "integrity": "sha512-NyhMEkziRXdQNO+etwyT6DPHlLaoF/YuZQ3Trfk1i9bReJgpk+j42V+8y0Y7v1XJ5IJPenEg3UOV6zYR4OexHg==",
-      "requires": {
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-eslint": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/mrm-task-eslint/-/mrm-task-eslint-2.0.15.tgz",
-      "integrity": "sha512-n6CHV/ITYHzBMmlRzLfN7My5/ee2DOIHzMJEiqEVklbdOKljRbrDH9y3CnrYnVxNfCAIx7+EBDAFIWWfte5EtQ==",
-      "requires": {
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-gitignore": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-gitignore/-/mrm-task-gitignore-2.0.14.tgz",
-      "integrity": "sha512-Hg6gSkua3MngZGruG9qj+/lphwWw3bK896ofZWw65KBhQ+p2rwkGdx5hj/NaQCCOvBxjjnIrckk4MPgtd2e4IA==",
-      "requires": {
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-jest": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-jest/-/mrm-task-jest-2.0.13.tgz",
-      "integrity": "sha512-ihQi5xyjIcrNEbHKKbF/w/micWaold0rmdLoQdbWhI3B8S6hOEBQFqoimaIi5N2vN9g+a/qN/HWU4+fWyeDvhg==",
-      "requires": {
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-license": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/mrm-task-license/-/mrm-task-license-3.1.4.tgz",
-      "integrity": "sha512-7Fq7UG253Ys3xygA7YmpUzUa/e/2uzVwdTghG2YcZeVqp1l8tzDKtBdTh0QY+IHQSWxT8uJpzpBvBwHMZHefBA==",
-      "requires": {
-        "mrm-core": "^4.5.0",
-        "parse-author": "^2.0.0",
-        "user-meta": "^1.0.0"
-      }
-    },
-    "mrm-task-lint-staged": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-lint-staged/-/mrm-task-lint-staged-3.0.13.tgz",
-      "integrity": "sha512-qlY6Cw/CtAx0G3Uz9LQjWi7j2FSBT0+NWTTsF7xEbBkIoY8bsxhIiPPpVZaxuALCGn6GxhY/qblNXn0fzvj+0g==",
-      "requires": {
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-package": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/mrm-task-package/-/mrm-task-package-2.1.7.tgz",
-      "integrity": "sha512-pXdoo0u8BiRNyNFgw6uOoT+bwNgHHh6pWjRo6JxAfaZeDRBwbCml3cJmch8cqrOhglMnO6HPuhQTWxy4ebXDfg==",
-      "requires": {
-        "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
-        "user-meta": "^1.0.0"
-      }
-    },
-    "mrm-task-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-prettier/-/mrm-task-prettier-3.1.2.tgz",
-      "integrity": "sha512-1U9atx7+XGGPoZcoNQbS1ZdinL8Jzkc5n3dYN5yq7NkbTimmXhUmDiYHPKPr0s0AL1RCcJRwVGIRRJ+rxL9BMw==",
-      "requires": {
-        "editorconfig-to-prettier": "0.1.1",
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-readme": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-readme/-/mrm-task-readme-2.1.3.tgz",
-      "integrity": "sha512-8IsCXEr9dju1DINHCW5FFz2lHZ1je0+OIf70n9K0WDVHpmxlI0KynrDwrcSTNyIsv1BwIq82uBmRboD94cjJmA==",
-      "requires": {
-        "git-username": "^1.0.0",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3",
-        "parse-author": "^2.0.0",
-        "user-meta": "^1.0.0"
-      }
-    },
-    "mrm-task-semantic-release": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mrm-task-semantic-release/-/mrm-task-semantic-release-4.0.3.tgz",
-      "integrity": "sha512-PU14NAe/fGOH/CeEbdLuxCoRq/x0FappM00QCV6MSU0qDBE6qh3VlHRSx4nKjPfrM/uehfumyLZaXpxZMg4EZg==",
-      "requires": {
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3"
-      }
-    },
-    "mrm-task-styleguidist": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-styleguidist/-/mrm-task-styleguidist-2.0.13.tgz",
-      "integrity": "sha512-K637ZjrnraK7Whhw8YHUqPFOfwvidXAr+i6ujWrdBY/MxYMVZ1wsnCKViuKf/cPtWd2AE1h9+wmLGSnnuiwPxQ==",
-      "requires": {
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-stylelint": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/mrm-task-stylelint/-/mrm-task-stylelint-3.0.14.tgz",
-      "integrity": "sha512-oRgZ1yMmhJvq40PL2476Q5cYbKvcvygA/vLDFu5/iRc3SJzQxTqFn7CBnkjsQpgNf4XxUglX8udckiTZcBkI4Q==",
-      "requires": {
-        "mrm-core": "^4.5.0"
-      }
-    },
-    "mrm-task-travis": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/mrm-task-travis/-/mrm-task-travis-2.1.2.tgz",
-      "integrity": "sha512-8mi/PccKokyYktI8UTQywEMvShlbLVtL04B3qTbp9fBgMQZ9ya4BzESeH0O/57pTbcvm8/3m0db7bkyf3g8TOQ==",
-      "requires": {
-        "lodash": "^4.17.15",
-        "mrm-core": "^4.5.0",
-        "package-repo-url": "^1.0.3",
-        "semver-utils": "^1.1.4"
-      }
-    },
-    "mrm-task-typescript": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/mrm-task-typescript/-/mrm-task-typescript-2.0.13.tgz",
-      "integrity": "sha512-jNRuMQd1uaidfcliMDuR8B30n1pMhCtyfzeRR310jf9b8Ie2cFcnr6pQ/v9xhu0RS0xZRO95rDZEUuFYnBADUA==",
-      "requires": {
-        "mrm-core": "^4.5.0"
-      }
-    },
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
@@ -4953,22 +4092,6 @@
         "semver": "^6.2.0"
       }
     },
-    "package-repo-url": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/package-repo-url/-/package-repo-url-1.0.3.tgz",
-      "integrity": "sha512-DcoCnScztg2NJ2JmVgdJT7b7uMaYCcQFQiq6/AXv1yNwYm5EloCKXNQJOXLYKBAkJzto6SIejkHOWz4uvCfRAA==",
-      "requires": {
-        "git-username": "^1.0.0"
-      }
-    },
-    "parse-author": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
-      "integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
-      "requires": {
-        "author-regex": "^1.0.0"
-      }
-    },
     "parse-git-config": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
@@ -5045,11 +4168,6 @@
         "escape-goat": "^2.0.0"
       }
     },
-    "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5107,11 +4225,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
-    },
-    "resolve-alpn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
-      "integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA=="
     },
     "responselike": {
       "version": "1.0.2",

--- a/packages/mrm/package.json
+++ b/packages/mrm/package.json
@@ -31,7 +31,6 @@
     "middleearth-names": "^1.1.0",
     "minimist": "^1.2.0",
     "mrm-core": "^4.5.0",
-    "mrm-preset-default": "^2.3.7",
     "semver-utils": "^1.1.4",
     "update-notifier": "^4.1.0",
     "user-home": "^2.0.0",


### PR DESCRIPTION
First step in deprecating the default preset as mentioned in #135.

I think actual deprecation must be performed with an `npm` command. We can remove the default preset from packages but I'm not sure if it should wait or be performed here as well.