### PR TITLE
feat(install/uninstall): add pnpm support (option or auto-detect)

### DIFF
--- a/packages/mrm-core/Readme.md
+++ b/packages/mrm-core/Readme.md
@@ -317,7 +317,7 @@ makeDirs('dir name'); // Create folder
 makeDirs(['dir name 1', 'dir name 2']); // Create folders
 ```
 
-### Install and uninstall npm or Yarn packages
+### Install and uninstall npm, Yarn, or pnpm packages
 
 Installs npm package(s) and saves them to `package.json` if they aren’t installed yet or not satisfying range.
 
@@ -350,6 +350,8 @@ const { install, uninstall } = require('mrm-core');
 uninstall(['eslint'], { yarn: true });
 install(['standard'], { yarn: true });
 ```
+
+With Yarn Berry, pass `yarnBerry: true` and for pnpm, pass `pnpm: true`.
 
 ### Utilities
 

--- a/packages/mrm-core/src/__tests__/npm.spec.js
+++ b/packages/mrm-core/src/__tests__/npm.spec.js
@@ -81,6 +81,17 @@ describe('install()', () => {
 		);
 	});
 
+	it('should install a pnpm packages to devDependencies', () => {
+		const spawn = jest.fn();
+		createPackageJson({}, {});
+		install(modules, { pnpm: true }, spawn);
+		expect(spawn).toBeCalledWith(
+			expect.stringMatching(/pnpm(\.cmd)?/),
+			['install', '--save-dev', 'eslint@latest', 'babel-core@latest'],
+			options
+		);
+	});
+
 	it('should install an npm packages to dependencies', () => {
 		const spawn = jest.fn();
 		createPackageJson({}, {});
@@ -115,6 +126,17 @@ describe('install()', () => {
 		expect(spawn).toBeCalledWith(
 			expect.stringMatching(/yarn(\.cmd)?/),
 			['add', 'eslint@latest', 'babel-core@latest'],
+			options
+		);
+	});
+
+	it('should install a pnpm packages to dependencies', () => {
+		const spawn = jest.fn();
+		createPackageJson({}, {});
+		install(modules, { dev: false, pnpm: true }, spawn);
+		expect(spawn).toBeCalledWith(
+			expect.stringMatching(/pnpm(\.cmd)?/),
+			['install', '--save', 'eslint@latest', 'babel-core@latest'],
 			options
 		);
 	});
@@ -361,7 +383,7 @@ describe('install()', () => {
 });
 
 describe('uninstall()', () => {
-	it('should uninstall an npm packages from devDependencies', () => {
+	it('should uninstall npm packages from devDependencies', () => {
 		const spawn = jest.fn();
 		createPackageJson(
 			{},
@@ -395,7 +417,24 @@ describe('uninstall()', () => {
 		);
 	});
 
-	it('should uninstall an npm packages from dependencies', () => {
+	it('should uninstall pnpm packages from devDependencies', () => {
+		const spawn = jest.fn();
+		createPackageJson(
+			{},
+			{
+				eslint: '*',
+				'babel-core': '*',
+			}
+		);
+		uninstall(modules, { pnpm: true }, spawn);
+		expect(spawn).toBeCalledWith(
+			expect.stringMatching(/npm(\.cmd)?/),
+			['uninstall', '--save-dev', 'eslint', 'babel-core'],
+			options
+		);
+	});
+
+	it('should uninstall npm packages from dependencies', () => {
 		const spawn = jest.fn();
 		createPackageJson(
 			{

--- a/packages/mrm-core/types/index.d.ts
+++ b/packages/mrm-core/types/index.d.ts
@@ -88,6 +88,8 @@ interface CopyFilesOptions {
 interface NpmOptions {
 	dev?: boolean;
 	yarn?: boolean;
+	yarnBerry?: boolean;
+	pnpm?: boolean;
 	versions?: Dependencies;
 }
 

--- a/packages/mrm-task-gitignore/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-gitignore/__snapshots__/index.spec.js.snap
@@ -13,7 +13,7 @@ Thumbs.db
 }
 `;
 
-exports[`should add package-lock.json, if yarn.lock exists 1`] = `
+exports[`should add package-lock.json and pnpm-lock.yaml, if yarn.lock exists 1`] = `
 Object {
   "/.gitignore": "node_modules/
 .DS_Store
@@ -23,12 +23,13 @@ Thumbs.db
 *.sublime-project
 *.sublime-workspace
 *.log
-package-lock.json",
+package-lock.json
+pnpm-lock.yaml",
   "/yarn.lock": "",
 }
 `;
 
-exports[`should add yarn.lock, if package-lock.json exists 1`] = `
+exports[`should add yarn.lock and pnpm-lock.yaml, if package-lock.json exists 1`] = `
 Object {
   "/.gitignore": "node_modules/
 .DS_Store
@@ -38,7 +39,24 @@ Thumbs.db
 *.sublime-project
 *.sublime-workspace
 *.log
-yarn.lock",
+yarn.lock
+pnpm-lock.yaml",
   "/package-lock.json": "",
+}
+`;
+
+exports[`should add package-lock.json and yarn.lock, if pnpm-lock.yaml exists 1`] = `
+Object {
+  "/.gitignore": "node_modules/
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+*.log
+yarn.lock
+package-lock.json",
+  "/pnpm-lock.yaml": "",
 }
 `;

--- a/packages/mrm-task-gitignore/index.js
+++ b/packages/mrm-task-gitignore/index.js
@@ -14,15 +14,24 @@ module.exports = function task() {
 		'*.log',
 	];
 
-	// If project uses npm, ignore yarn.lock
+	// If project uses npm, ignore yarn.lock and pnpm-lock.yaml
 	if (fs.existsSync('package-lock.json')) {
 		add.push('yarn.lock');
+		add.push('pnpm-lock.yaml');
 		remove.push('package-lock.json');
 	}
 
-	// If project uses Yarn, ignore package-lock.json
+	// If project uses Yarn, ignore package-lock.json and pnpm-lock.yaml
 	if (fs.existsSync('yarn.lock')) {
 		remove.push('yarn.lock');
+		add.push('package-lock.json');
+		add.push('pnpm-lock.yaml');
+	}
+
+	// If project uses pnpm, ignore package-lock.json and yarn.lock
+	if (fs.existsSync('pnpm-lock.yaml')) {
+		remove.push('pnpm-lock.yaml');
+		add.push('yarn.lock');
 		add.push('package-lock.json');
 	}
 

--- a/packages/mrm-task-gitignore/index.spec.js
+++ b/packages/mrm-task-gitignore/index.spec.js
@@ -17,7 +17,7 @@ it('should add .gitignore', async () => {
 	expect(vol.toJSON()).toMatchSnapshot();
 });
 
-it('should add package-lock.json, if yarn.lock exists', async () => {
+it('should add package-lock.json and pnpm-lock.yaml, if yarn.lock exists', async () => {
 	vol.fromJSON({
 		'/yarn.lock': '',
 	});
@@ -27,9 +27,19 @@ it('should add package-lock.json, if yarn.lock exists', async () => {
 	expect(vol.toJSON()).toMatchSnapshot();
 });
 
-it('should add yarn.lock, if package-lock.json exists', async () => {
+it('should add yarn.lock and pnpm-lock.yaml, if package-lock.json exists', async () => {
 	vol.fromJSON({
 		'/package-lock.json': '',
+	});
+
+	task(await getTaskOptions(task, false, {}));
+
+	expect(vol.toJSON()).toMatchSnapshot();
+});
+
+it('should add package-lock.json and yarn.lock, if pnpm-lock.yaml exists', async () => {
+	vol.fromJSON({
+		'/pnpm-lock.yaml': '',
 	});
 
 	task(await getTaskOptions(task, false, {}));

--- a/packages/mrm-task-package/index.js
+++ b/packages/mrm-task-package/index.js
@@ -4,6 +4,7 @@ const path = require('path');
 const meta = require('user-meta');
 const gitUsername = require('git-username');
 const { json } = require('mrm-core');
+const rc = require('rc');
 
 const rc = require('rc');
 
@@ -70,7 +71,10 @@ module.exports = function task({
 
 	const lockFile = path.join(__dirname, lockFileBase);
 	if (!fs.existsSync(lockFile)) {
-		fs.closeSync(fs.openSync(lockFile, 'w'));
+		const npmrc = rc('npm', null, []);
+		if (packageManager !== 'npm' || !npmrc || npmrc['package-lock'] !== false) {
+			fs.closeSync(fs.openSync(lockFile, 'w'));
+		}
 	}
 
 	// Update

--- a/packages/mrm-task-package/index.js
+++ b/packages/mrm-task-package/index.js
@@ -6,8 +6,6 @@ const gitUsername = require('git-username');
 const { json } = require('mrm-core');
 const rc = require('rc');
 
-const rc = require('rc');
-
 function getConfig() {
 	const npm = rc('npm', null, []);
 	return {

--- a/packages/mrm-task-package/index.js
+++ b/packages/mrm-task-package/index.js
@@ -1,4 +1,5 @@
 // @ts-check
+const fs = require('fs');
 const path = require('path');
 const meta = require('user-meta');
 const gitUsername = require('git-username');
@@ -21,6 +22,7 @@ module.exports = function task({
 	minNode,
 	license,
 	version,
+	packageManager,
 }) {
 	const packageName = path.basename(process.cwd());
 	const repository = `${github}/${packageName}`;
@@ -49,6 +51,27 @@ module.exports = function task({
 		dependencies: {},
 		devDependencies: {},
 	});
+
+	let lockFileBase;
+	switch (packageManager) {
+		case 'npm':
+			lockFileBase = 'package-lock.json';
+			break;
+		case 'pnpm':
+			lockFileBase = 'pnpm-lock.yaml';
+			break;
+		case 'Yarn':
+			lockFileBase = 'yarn.lock';
+			break;
+		case 'Yarn Berry':
+			lockFileBase = '.yarnrc.yml';
+			break;
+	}
+
+	const lockFile = path.join(__dirname, lockFileBase);
+	if (!fs.existsSync(lockFile)) {
+		fs.closeSync(fs.openSync(lockFile, 'w'));
+	}
 
 	// Update
 	if (pkg.exists()) {
@@ -99,5 +122,11 @@ module.exports.parameters = {
 		type: 'input',
 		message: 'Enter project license',
 		default: () => getConfig().license || 'MIT',
+	},
+	packageManager: {
+		type: 'list',
+		message: 'Enter the package manager to use',
+		choices: ['npm', 'pnpm', 'Yarn', 'Yarn Berry'],
+		default: 'npm',
 	},
 };

--- a/packages/mrm-task-package/index.spec.js
+++ b/packages/mrm-task-package/index.spec.js
@@ -30,7 +30,64 @@ it('should add package.json', async () => {
 	expect(vol.toJSON()[path.join(__dirname, 'package.json')]).toMatchSnapshot();
 });
 
+it('should add yarn.lock if packageManager is Yarn', async () => {
+	// The task will use the folder name as a package name
+	vol.mkdirpSync(__dirname);
+	process.chdir(__dirname);
+
+	task(
+		await getTaskOptions(
+			task,
+			false,
+			Object.assign({}, options, {
+				packageManager: 'Yarn',
+			})
+		)
+	);
+
+	expect(vol.toJSON()[path.join(__dirname, 'yarn.lock')]).toBeDefined();
+});
+
+it('should add .yarnrc.yml if packageManager is Yarn Berry', async () => {
+	// The task will use the folder name as a package name
+	vol.mkdirpSync(__dirname);
+	process.chdir(__dirname);
+
+	task(
+		await getTaskOptions(
+			task,
+			false,
+			Object.assign({}, options, {
+				packageManager: 'Yarn Berry',
+			})
+		)
+	);
+
+	expect(vol.toJSON()[path.join(__dirname, '.yarnrc.yml')]).toBeDefined();
+});
+
+it('should add pnpm-lock.yaml if packageManager is pnpm', async () => {
+	// The task will use the folder name as a package name
+	vol.mkdirpSync(__dirname);
+	process.chdir(__dirname);
+
+	task(
+		await getTaskOptions(
+			task,
+			false,
+			Object.assign({}, options, {
+				packageManager: 'pnpm',
+			})
+		)
+	);
+
+	expect(vol.toJSON()[path.join(__dirname, 'pnpm-lock.yaml')]).toBeDefined();
+});
+
 it('should set custom Node.js version', async () => {
+	vol.fromJSON({
+		[`${__dirname}/package-lock.json`]: '',
+	});
 	task(
 		await getTaskOptions(
 			task,
@@ -44,6 +101,9 @@ it('should set custom Node.js version', async () => {
 });
 
 it('should set custom license', async () => {
+	vol.fromJSON({
+		[`${__dirname}/package-lock.json`]: '',
+	});
 	task(
 		await getTaskOptions(
 			task,

--- a/packages/mrm-task-package/index.spec.js
+++ b/packages/mrm-task-package/index.spec.js
@@ -30,6 +30,70 @@ it('should add package.json', async () => {
 	expect(vol.toJSON()[path.join(__dirname, 'package.json')]).toMatchSnapshot();
 });
 
+it('should add package-lock.json if packageManager is npm', async () => {
+	// The task will use the folder name as a package name
+	vol.mkdirpSync(__dirname);
+	process.chdir(__dirname);
+
+	task(
+		await getTaskOptions(
+			task,
+			false,
+			Object.assign({}, options, {
+				packageManager: 'npm',
+			})
+		)
+	);
+
+	expect(vol.toJSON()[path.join(__dirname, 'package-lock.json')]).toBeDefined();
+});
+
+it('should not add package-lock.json if npmrc has false for package-lock.json', async () => {
+	vol.fromJSON({
+		[`${__dirname}/.npmrc`]: 'package-lock=false',
+	});
+
+	// The task will use the folder name as a package name
+	vol.mkdirpSync(__dirname);
+	process.chdir(__dirname);
+
+	task(
+		await getTaskOptions(
+			task,
+			false,
+			Object.assign({}, options, {
+				packageManager: 'npm',
+			})
+		)
+	);
+
+	expect(
+		vol.toJSON()[path.join(__dirname, 'package-lock.json')]
+	).not.toBeDefined();
+});
+
+it('should add package-lock.json if npmrc has true for package-lock.json', async () => {
+	vol.fromJSON({
+		[`${__dirname}/.npmrc`]: 'package-lock=true',
+	});
+
+	// The task will use the folder name as a package name
+	vol.mkdirpSync(__dirname);
+	process.chdir(__dirname);
+
+	task(
+		await getTaskOptions(
+			task,
+			false,
+			Object.assign({}, options, {
+				packageManager: 'npm',
+			})
+		)
+	);
+
+	expect(vol.toJSON()[path.join(__dirname, 'package-lock.json')]).toBeDefined();
+});
+
 it('should add yarn.lock if packageManager is Yarn', async () => {
 	// The task will use the folder name as a package name
 	vol.mkdirpSync(__dirname);


### PR DESCRIPTION
feat(install/uninstall): add pnpm support (option or auto-detect)

This fixes the part of #114 which brings pnpm into parity with existing Yarn/YarnBerry support.