### PR TITLE
Fix broken lint-staged action by explicitly pining Husky to 4.x

### DIFF
--- a/packages/mrm-task-lint-staged/index.js
+++ b/packages/mrm-task-lint-staged/index.js
@@ -4,7 +4,7 @@ const { castArray } = require('lodash');
 
 const packages = {
 	'lint-staged': '>=10',
-	husky: '>=4',
+	husky: '=4',
 };
 
 /**

--- a/packages/mrm-task-lint-staged/index.spec.js
+++ b/packages/mrm-task-lint-staged/index.spec.js
@@ -56,7 +56,7 @@ it('should add Prettier if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '>=4' });
+	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
 });
 
 it('should add Prettier and ESLint', async () => {
@@ -128,7 +128,7 @@ it('should add ESLint if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '>=4' });
+	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
 });
 
 it('should use default JS extension if eslint command has no --ext key', async () => {
@@ -238,7 +238,7 @@ it('should add stylelint if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '>=4' });
+	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
 });
 
 it('should use a custom stylelint extension', async () => {
@@ -325,7 +325,7 @@ it('should merge rules with the same pattern', async () => {
 	);
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '>=4' });
+	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
 });
 
 it('should remove husky 0.14 config from package.json', async () => {

--- a/packages/mrm-task-lint-staged/index.spec.js
+++ b/packages/mrm-task-lint-staged/index.spec.js
@@ -277,7 +277,7 @@ it('should add a custom rule', async () => {
 	);
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '>=4' });
+	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
 });
 
 it('should update an existing rule', async () => {
@@ -297,7 +297,7 @@ it('should update an existing rule', async () => {
 	task(await getTaskOptions(task, false));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '>=4' });
+	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
 });
 
 it('should merge rules with the same pattern', async () => {


### PR DESCRIPTION
Longer-term, mrm should look at offering the option and being compatible with both 4/5, but for now, pinning @ 4 prevents the lint-staged action from being broken.

See https://github.com/sapegin/mrm/issues/145

Tested locally using `npm link`.