### PR TITLE
Replace husky 4 to simple-git-hooks

### DIFF
--- a/packages/mrm-task-lint-staged/__snapshots__/index.spec.js.snap
+++ b/packages/mrm-task-lint-staged/__snapshots__/index.spec.js.snap
@@ -7,10 +7,8 @@ Object {
   \\"devDependencies\\": {
     \\"eslint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.js\\": \\"eslint --cache --fix\\"
@@ -28,10 +26,8 @@ Object {
     \\"eslint\\": \\"4.0.1\\",
     \\"prettier\\": \\"1.9.2\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.js\\": \\"eslint --cache --fix\\",
@@ -48,10 +44,8 @@ Object {
   \\"devDependencies\\": {
     \\"prettier\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.{js,css,md}\\": \\"prettier --write\\"
@@ -67,10 +61,8 @@ Object {
   \\"devDependencies\\": {
     \\"eslint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.js\\": [
@@ -89,10 +81,8 @@ Object {
   \\"devDependencies\\": {
     \\"stylelint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.css\\": \\"stylelint --fix\\"
@@ -110,10 +100,8 @@ exports[`should infer ESLint extension for an npm script 1`] = `
   \\"devDependencies\\": {
     \\"eslint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.{js,jsx}\\": \\"eslint --cache --fix\\"
@@ -130,10 +118,8 @@ exports[`should infer Prettier extensions from an npm script 1`] = `
   \\"devDependencies\\": {
     \\"prettier\\": \\"1.9.2\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.{js,jsx}\\": \\"prettier --write\\"
@@ -156,10 +142,8 @@ Object {
       \\"prettier --write\\"
     ]
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   }
 }",
 }
@@ -173,10 +157,25 @@ Object {
   \\"devDependencies\\": {
     \\"eslint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
+  },
+  \\"lint-staged\\": {
+    \\"*.js\\": \\"eslint --cache --fix\\"
+  }
+}",
+}
+`;
+
+exports[`should remove husky 4 config from package.json 1`] = `
+Object {
+  "/package.json": "{
+  \\"name\\": \\"unicorn\\",
+  \\"devDependencies\\": {
+    \\"eslint\\": \\"*\\"
+  },
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.js\\": \\"eslint --cache --fix\\"
@@ -196,10 +195,8 @@ Object {
     \\"*.md\\": \\"textlint --fix\\",
     \\"*.js\\": \\"eslint --cache --fix\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   }
 }",
 }
@@ -212,10 +209,8 @@ Object {
   \\"devDependencies\\": {
     \\"eslint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.{js,jsx}\\": \\"eslint --cache --fix\\"
@@ -231,10 +226,8 @@ Object {
   \\"devDependencies\\": {
     \\"stylelint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.scss\\": \\"stylelint --fix\\"
@@ -250,10 +243,8 @@ Object {
   \\"devDependencies\\": {
     \\"prettier\\": \\"1.9.2\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.{js,jsx,mjs}\\": \\"prettier --write\\"
@@ -271,10 +262,8 @@ exports[`should use default JS extension if eslint command has no --ext key 1`] 
   \\"devDependencies\\": {
     \\"eslint\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.js\\": \\"eslint --cache --fix\\"
@@ -290,10 +279,8 @@ Object {
     \\"eslint\\": \\"*\\",
     \\"prettier\\": \\"*\\"
   },
-  \\"husky\\": {
-    \\"hooks\\": {
-      \\"pre-commit\\": \\"lint-staged\\"
-    }
+  \\"simple-git-hooks\\": {
+    \\"pre-commit\\": \\"npx lint-staged\\"
   },
   \\"lint-staged\\": {
     \\"*.{js,css,md}\\": \\"prettier --write\\"

--- a/packages/mrm-task-lint-staged/index.js
+++ b/packages/mrm-task-lint-staged/index.js
@@ -1,5 +1,10 @@
 // @ts-check
-const { packageJson, install, getExtsFromCommand } = require('mrm-core');
+const {
+	packageJson,
+	install,
+	getExtsFromCommand,
+	uninstall,
+} = require('mrm-core');
 const { castArray } = require('lodash');
 
 const packages = {
@@ -183,6 +188,7 @@ module.exports = function task({ lintStagedRules }) {
 		})
 		.save();
 
+	uninstall('husky');
 	// Install dependencies
 	install(packages);
 };

--- a/packages/mrm-task-lint-staged/index.js
+++ b/packages/mrm-task-lint-staged/index.js
@@ -4,7 +4,7 @@ const { castArray } = require('lodash');
 
 const packages = {
 	'lint-staged': '>=10',
-	husky: '=4',
+	'simple-git-hooks': '>=2.0.3',
 };
 
 /**
@@ -172,12 +172,12 @@ module.exports = function task({ lintStagedRules }) {
 	pkg
 		// Remove husky 0.14 config
 		.unset('scripts.precommit')
+		// Remove husky 4 config
+		.unset('husky')
 		// Add new config
 		.merge({
-			husky: {
-				hooks: {
-					'pre-commit': 'lint-staged',
-				},
+			'simple-git-hooks': {
+				'pre-commit': 'npx lint-staged',
 			},
 			'lint-staged': rules,
 		})

--- a/packages/mrm-task-lint-staged/index.spec.js
+++ b/packages/mrm-task-lint-staged/index.spec.js
@@ -1,9 +1,10 @@
 jest.mock('fs');
 jest.mock('mrm-core/src/npm', () => ({
+	uninstall: jest.fn(),
 	install: jest.fn(),
 }));
 
-const { install } = require('mrm-core');
+const { install, uninstall } = require('mrm-core');
 const { getTaskOptions } = require('mrm');
 const vol = require('memfs').vol;
 const task = require('./index');
@@ -26,6 +27,7 @@ beforeEach(() => {
 afterEach(() => {
 	vol.reset();
 	install.mockClear();
+	uninstall.mockClear();
 	console.log = console$log;
 });
 
@@ -56,6 +58,7 @@ it('should add Prettier if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
+	expect(uninstall).toBeCalledWith('husky');
 	expect(install).toBeCalledWith({
 		'lint-staged': '>=10',
 		'simple-git-hooks': '>=2.0.3',
@@ -131,6 +134,7 @@ it('should add ESLint if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
+	expect(uninstall).toBeCalledWith('husky');
 	expect(install).toBeCalledWith({
 		'lint-staged': '>=10',
 		'simple-git-hooks': '>=2.0.3',
@@ -286,6 +290,7 @@ it('should add a custom rule', async () => {
 	);
 
 	expect(vol.toJSON()).toMatchSnapshot();
+	expect(uninstall).toBeCalledWith('husky');
 	expect(install).toBeCalledWith({
 		'lint-staged': '>=10',
 		'simple-git-hooks': '>=2.0.3',
@@ -309,6 +314,7 @@ it('should update an existing rule', async () => {
 	task(await getTaskOptions(task, false));
 
 	expect(vol.toJSON()).toMatchSnapshot();
+	expect(uninstall).toBeCalledWith('husky');
 	expect(install).toBeCalledWith({
 		'lint-staged': '>=10',
 		'simple-git-hooks': '>=2.0.3',
@@ -340,6 +346,7 @@ it('should merge rules with the same pattern', async () => {
 	);
 
 	expect(vol.toJSON()).toMatchSnapshot();
+	expect(uninstall).toBeCalledWith('husky');
 	expect(install).toBeCalledWith({
 		'lint-staged': '>=10',
 		'simple-git-hooks': '>=2.0.3',

--- a/packages/mrm-task-lint-staged/index.spec.js
+++ b/packages/mrm-task-lint-staged/index.spec.js
@@ -56,7 +56,10 @@ it('should add Prettier if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
+	expect(install).toBeCalledWith({
+		'lint-staged': '>=10',
+		'simple-git-hooks': '>=2.0.3',
+	});
 });
 
 it('should add Prettier and ESLint', async () => {
@@ -128,7 +131,10 @@ it('should add ESLint if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
+	expect(install).toBeCalledWith({
+		'lint-staged': '>=10',
+		'simple-git-hooks': '>=2.0.3',
+	});
 });
 
 it('should use default JS extension if eslint command has no --ext key', async () => {
@@ -238,7 +244,10 @@ it('should add stylelint if project depends on it', async () => {
 	task(await getTaskOptions(task));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
+	expect(install).toBeCalledWith({
+		'lint-staged': '>=10',
+		'simple-git-hooks': '>=2.0.3',
+	});
 });
 
 it('should use a custom stylelint extension', async () => {
@@ -277,7 +286,10 @@ it('should add a custom rule', async () => {
 	);
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
+	expect(install).toBeCalledWith({
+		'lint-staged': '>=10',
+		'simple-git-hooks': '>=2.0.3',
+	});
 });
 
 it('should update an existing rule', async () => {
@@ -297,7 +309,10 @@ it('should update an existing rule', async () => {
 	task(await getTaskOptions(task, false));
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
+	expect(install).toBeCalledWith({
+		'lint-staged': '>=10',
+		'simple-git-hooks': '>=2.0.3',
+	});
 });
 
 it('should merge rules with the same pattern', async () => {
@@ -325,7 +340,10 @@ it('should merge rules with the same pattern', async () => {
 	);
 
 	expect(vol.toJSON()).toMatchSnapshot();
-	expect(install).toBeCalledWith({ 'lint-staged': '>=10', husky: '=4' });
+	expect(install).toBeCalledWith({
+		'lint-staged': '>=10',
+		'simple-git-hooks': '>=2.0.3',
+	});
 });
 
 it('should remove husky 0.14 config from package.json', async () => {
@@ -334,6 +352,26 @@ it('should remove husky 0.14 config from package.json', async () => {
 			name: 'unicorn',
 			scripts: {
 				precommit: 'lint-staged',
+			},
+			devDependencies: {
+				eslint: '*',
+			},
+		}),
+	});
+
+	task(await getTaskOptions(task));
+
+	expect(vol.toJSON()).toMatchSnapshot();
+});
+
+it('should remove husky 4 config from package.json', async () => {
+	vol.fromJSON({
+		'/package.json': stringify({
+			name: 'unicorn',
+			husky: {
+				hooks: {
+					'pre-commit': 'lint-staged',
+				},
 			},
 			devDependencies: {
 				eslint: '*',


### PR DESCRIPTION
[`simple-git-hooks`](https://github.com/toplenboren/simple-git-hooks) is a git hook manager.

This migration will bring these benefits to users:
* `simple-git-hooks` has 0 dependencies and took 10 KB of `node_modules` space compared to 1 MB of husky 4.
* `simple-git-hooks` doesn’t read config on every `pre-commit` hook call which increases the performance. It uses the husky 5 model when you need explicitly to call a script on config changes. But it is a good trade-off for `lint-staged` case. It should give around a 0.5 second performance boost for `pre-commit`.

Comparison with husky 5:
1. We can start having all husky 5 benefits (performance, small size) without waiting for MIT license for husky 5.
2. `simple-git-hooks` is smaller than husky 5.
3. husky 5 [requires](https://github.com/typicode/husky/issues/868) extra scripts in `package.json`.
4. husky 5 [requires](https://typicode.github.io/husky/#/?id=yarn-v2) an extra `pinst` dependency for Yarn 2. `simple-git-hooks` has [out-of-the box](https://github.com/toplenboren/simple-git-hooks/issues/30) Yarn 2 support.

I already tested `simple-git-hooks` on Autoprefixer, PostCSS, Browserslist, and my commercial projects (with a big team). Everything works great. Other people [reported](https://twitter.com/smithua/status/1372490975029911559) about successful migration too. @toplenboren `simple-git-hooks` maintainer is always open for the changes and answers quickly.