### PR TITLE
fix(site): Non-clickable links when goatcounter is blocked

### DIFF
--- a/site/src/plugins/goatcounter-plugin.js
+++ b/site/src/plugins/goatcounter-plugin.js
@@ -5,7 +5,7 @@ module.exports = function() {
 			return {
 				headTags: [
 					`<script>
-if ('history' in window) {
+if ('history' in window && 'goatcounter' in window) {
 	function trackView() {
 		window.goatcounter.count({
 			path: location.pathname + location.search,


### PR DESCRIPTION
When the browser fails to load goatcounter (for example, if one blocked by adblocker), clicking on links throws the error:
`Uncaught TypeError: can't access property "count", window.goatcounter is undefined` and prevents any site navigation.