### PR TITLE
fix(site): Non-clickable links when goatcounter is blocked

### DIFF
--- a/site/src/plugins/goatcounter-plugin.js
+++ b/site/src/plugins/goatcounter-plugin.js
@@ -7,9 +7,11 @@ module.exports = function() {
 					`<script>
 if ('history' in window) {
 	function trackView() {
-		window.goatcounter.count({
-			path: location.pathname + location.search,
-		});
+		if ('goatcounter' in window) {
+			window.goatcounter.count({
+				path: location.pathname + location.search,
+			});
+		}
 	}
 
 	// Monkey patch browser pushState


### PR DESCRIPTION
When the browser fails to load goatcounter (for example, if one blocked by adblocker), clicking on links throws the error:
`Uncaught TypeError: can't access property "count", window.goatcounter is undefined` and prevents any site navigation.