### PR TITLE
Remove the require assuming that default preset is installed

### DIFF
--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -162,10 +162,6 @@ Note that when a preset is specified no default search locations are used.`
 			paths.unshift(dir);
 		}
 
-		if (isDefaultPreset) {
-			return [...paths, path.dirname(require.resolve('mrm-preset-default'))];
-		}
-
 		const presetPackageName = getPackageName('preset', preset);
 		try {
 			const presetPath = await promiseFirst([


### PR DESCRIPTION
Feels like we need a (possibly e2e) regression test but since this is a serious breaking error, fix is our priority.

I tested this locally and it worked.