### PR TITLE
fix: mrm reports file not found although it exists

### DIFF
--- a/packages/mrm-core/src/formats/markdown.js
+++ b/packages/mrm-core/src/formats/markdown.js
@@ -32,7 +32,7 @@ module.exports = function(filename) {
 		 * @param {string} altText
 		 */
 		addBadge(imageUrl, linkUrl, altText) {
-			if (!content) {
+			if (!file.exists()) {
 				throw new MrmError(`Can’t add badge: file “${filename}” not found.`);
 			}
 


### PR DESCRIPTION
When I ran `npx mrm semantic-release --config:readmeFile=README.md` in my terminal, something unexpected happened

I already had a `README.md` in my project( it's empty though ), but `mrm` still reported

```bash
Can’t add badge: file “README.md” not found.
```

It makes me confused. So I digged into the code a bit

Finally I found the reason( See the `Files changed` part in this PR )