### PR TITLE
fix: peer and obsolete deps is not optional

### DIFF
--- a/packages/mrm-task-eslint/index.js
+++ b/packages/mrm-task-eslint/index.js
@@ -39,8 +39,8 @@ const normalizePresetPackageName = presetName => {
 
 module.exports = function task({
 	eslintPreset,
-	eslintPeerDependencies,
-	eslintObsoleteDependencies,
+	eslintPeerDependencies = [],
+	eslintObsoleteDependencies = [],
 	eslintRules,
 }) {
 	let exts = '';


### PR DESCRIPTION
The readme in `mrm-task-eslint` says, `eslintPeerDependencies` and `eslintObsoleteDependencies` are optional

```js
require( 'mrm-task-eslint' )( {
  eslintPreset: '...',
  eslintPeerDependencies: [],
  eslintObsoleteDependencies: [],
} )
```

But in fact, if I use `mrm-task-eslint` in the programming way, I must pass an empty array for them, or it will report an error

```bash
TypeError: eslintPeerDependencies/eslintObsoleteDependencies is not iterable
```

We should add default value ( empty array ) for them, not only in `module.exports.parameters`