### PR TITLE
fix: yarn.lock is not added to .gitignore

### DIFF
--- a/packages/mrm-task-gitignore/index.js
+++ b/packages/mrm-task-gitignore/index.js
@@ -22,8 +22,8 @@ module.exports = function task() {
 
 	// If project uses Yarn, ignore package-lock.json
 	if (fs.existsSync('yarn.lock')) {
-		remove.push('yarn.lock');
-		add.push('package-lock.json');
+		add.push('yarn.lock');
+		remove.push('package-lock.json');
 	}
 
 	// .gitignore


### PR DESCRIPTION
`yarn.lock` is not added to .gitignore even if the yarn.lock file exists