### PR TITLE
fix: `Cannot read property 'length' of undefined` when listing tasks

### DIFF
--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -208,7 +208,7 @@ We’ve tried to load “${presetPackageName}” and “${preset}” npm package
 	function getTasksList() {
 		const allTasks = getAllTasks(directories, options);
 		const names = sortBy(Object.keys(allTasks));
-		const nameColWidth = longest(names).length;
+		const nameColWidth = names.length > 0 ? longest(names).length : 0;
 
 		return names
 			.map(name => {

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -102,7 +102,9 @@ describe('tryFile', () => {
 describe('resolveUsingNpx', () => {
 	it('should install an npm module transparently', async () => {
 		const result = await resolveUsingNpx('yarnhook');
-		expect(result).toMatch(/\.npm\/_npx\/\d*\/lib\/node_modules\/yarnhook$/);
+		expect(result).toMatch(
+			/\.npm\/_npx\/\d*\/lib(64)?\/node_modules\/yarnhook\/index\.js$/
+		);
 	});
 
 	it('should throw if npm module is not found on the registry', () => {

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -312,8 +312,12 @@ function tryFile(directories, filename) {
 async function resolveUsingNpx(packageName) {
 	const npm = which.sync('npm');
 	const { prefix } = await npx._ensurePackages(packageName, { npm, q: true });
-	const packagePath = path.join(prefix, 'lib', 'node_modules', packageName);
-	return packagePath;
+	return require.resolve(packageName, {
+		paths: [
+			path.join(prefix, 'lib', 'node_modules'),
+			path.join(prefix, 'lib64', 'node_modules'),
+		],
+	});
 }
 
 /**


### PR DESCRIPTION
See individual commit messages for details. Fixes #160 (and duplicate #178)