### PR TITLE
Feature/default preset

### DIFF
--- a/docs/Making_presets.md
+++ b/docs/Making_presets.md
@@ -59,3 +59,13 @@ The package name should should follow this pattern: `mrm-preset-<TASK>`, otherwi
 mrm license --preset unicorn # mrm-preset-unicorn
 mrm license --preset @mycompany/unicorn-preset # @mycompany/unicorn-preset
 ```
+
+## Default preset
+
+The default preset is `mrm-preset-default`, you can set a custom default preset in `.mrm/config.json`:
+
+```json
+{
+  "preset": "@mycompany/unicorn"
+}
+```

--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -65,7 +65,8 @@ async function main() {
 		binaryPath && binaryPath.endsWith('/npx') ? 'npx mrm' : 'mrm';
 
 	// Preset
-	const preset = argv.preset || 'default';
+	const userConfig = await getConfig(defaultDirectories, 'config.json', argv);
+	const preset = argv.preset || userConfig.preset || 'default';
 	const isDefaultPreset = preset === 'default';
 	const directories = await resolveDirectories(defaultDirectories);
 	const options = await getConfig(directories, 'config.json', argv);

--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -73,7 +73,7 @@ async function main() {
 	if (tasks.length === 0 || tasks[0] === 'help') {
 		commandHelp();
 	} else {
-		run(tasks, directories, options, argv).catch(err => {
+		run(tasks, directories, preset, options, argv).catch(err => {
 			if (err.constructor === MrmUnknownAlias) {
 				printError(err.message);
 			} else if (err.constructor === MrmUnknownTask) {

--- a/packages/mrm/src/index.js
+++ b/packages/mrm/src/index.js
@@ -66,15 +66,16 @@ function promiseSeries(items, iterator) {
  *
  * @param {string|string[]} name
  * @param {string[]} directories
+ * @param {string} preset
  * @param {Object} options
  * @param {Object} argv
  * @returns {Promise}
  */
-function run(name, directories, options, argv) {
+function run(name, directories, preset, options, argv) {
 	if (Array.isArray(name)) {
 		return new Promise((resolve, reject) => {
 			promiseSeries(name, n => {
-				return run(n, directories, options, argv);
+				return run(n, directories, preset, options, argv);
 			})
 				.then(() => resolve())
 				.catch(reject);
@@ -82,9 +83,9 @@ function run(name, directories, options, argv) {
 	}
 
 	if (getAllAliases(options)[name]) {
-		return runAlias(name, directories, options, argv);
+		return runAlias(name, directories, preset, options, argv);
 	}
-	return runTask(name, directories, options, argv);
+	return runTask(name, directories, preset, options, argv);
 }
 
 /**
@@ -92,11 +93,12 @@ function run(name, directories, options, argv) {
  *
  * @param {string} aliasName
  * @param {string[]} directories
+ * @param {string} preset
  * @param {Object} options
  * @param {Object} [argv]
  * @returns {Promise}
  */
-function runAlias(aliasName, directories, options, argv) {
+function runAlias(aliasName, directories, preset, options, argv) {
 	return new Promise((resolve, reject) => {
 		const tasks = getAllAliases(options)[aliasName];
 		if (!tasks) {
@@ -107,7 +109,7 @@ function runAlias(aliasName, directories, options, argv) {
 		console.log(kleur.yellow(`Running alias ${aliasName}...`));
 
 		promiseSeries(tasks, name => {
-			return runTask(name, directories, options, argv);
+			return runTask(name, directories, preset, options, argv);
 		})
 			.then(() => resolve())
 			.catch(reject);
@@ -133,11 +135,12 @@ function getPackageName(type, packageName) {
  *
  * @param {string} taskName
  * @param {string[]} directories
+ * @param {string} preset
  * @param {Object} options
  * @param {Object} [argv]
  * @returns {Promise}
  */
-async function runTask(taskName, directories, options, argv) {
+async function runTask(taskName, directories, preset, options, argv) {
 	const taskPackageName = getPackageName('task', taskName);
 	let modulePath;
 	try {
@@ -169,7 +172,7 @@ async function runTask(taskName, directories, options, argv) {
 			return;
 		}
 
-		console.log(kleur.cyan(`Running ${taskName}...`));
+		console.log(kleur.cyan(`Running ${taskName} (from preset "${preset}")...`));
 
 		Promise.resolve(getTaskOptions(module, argv.interactive, options))
 			.then(config => module(config, argv))


### PR DESCRIPTION
Allows users to specify their own custom default preset.

In my opinion the strength of `mrm` is not the default tasks but the ability to create your own presets and tasks to setup applications and repositories. The default tasks interferes, uses the wrong configuration and is in general incomplete for my purposes. The major issue is that with an organization or company you want more control over the configuration.

By setting my own default preset it is easier to ensure that `npx mrm eslint` will setup eslint my way. Actively entering `--preset @mycompany/unicorn` is tedious when you want to run it across multiple repositories or when you want to run multiple tasks sequentially (i.e. task, commit, task, commit).

I do recognize that it might be a bit of documentation issue since `npx mrm mytask` might to different things on different machines but I hope the changes to output makes it more clear:

> Running mytask (from preset "@mycompany/unicorn")...
