### PR TITLE
refactor: use user's local node_module version of lint-staged

### DIFF
--- a/packages/mrm-task-lint-staged/index.js
+++ b/packages/mrm-task-lint-staged/index.js
@@ -213,7 +213,7 @@ module.exports = function task({ lintStagedRules }) {
 	// Install husky
 	husky.install();
 	// Set lint-staged config
-	husky.add('.husky/pre-commit', 'npx lint-staged');
+	husky.add('.husky/pre-commit', '$(npm bin)lint-staged');
 };
 
 module.exports.description = 'Adds lint-staged';


### PR DESCRIPTION
This change makes sure that the user is not pulling a random version of lint-staged that doesn't match the one in their package.json