### PR TITLE
Add script creating .mrm local folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:coverage": "jest --coverage",
     "lint": "eslint . --cache --fix",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --loglevel warn --write \"**/*.{js,md}\""
+    "format": "prettier --loglevel warn --write \"**/*.{js,md}\"",
+    "local": "bash to-local.sh"
   },
   "engines": {
     "node": ">=10.13"

--- a/to-local.sh
+++ b/to-local.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -rf $HOME/.mrm
+mkdir -p $HOME/.mrm
+find $(pwd) -maxdepth 2 -type d -name 'mrm-task*' | while read DIR; do
+	BASENAME=$(basename $DIR)
+	ln -sf $DIR $HOME/.mrm/${BASENAME/mrm-task-/}
+done

--- a/to-local.sh
+++ b/to-local.sh
@@ -2,9 +2,14 @@
 
 set -e
 
-rm -rf $HOME/.mrm
 mkdir -p $HOME/.mrm
 find $(pwd) -maxdepth 2 -type d -name 'mrm-task*' | while read DIR; do
 	BASENAME=$(basename $DIR)
-	ln -sf $DIR $HOME/.mrm/${BASENAME/mrm-task-/}
+	TASK=$HOME/.mrm/${BASENAME/mrm-task-/}
+	if [ -f $TASK -o -L $TASK ]; then
+		echo "$TASK already exists, skipping"
+	else
+		echo "Linking $DIR to your local $TASK"
+		ln -s $DIR $TASK
+	fi
 done


### PR DESCRIPTION
This script maps your local checkout to your `$HOME/.mrm` folder as tasks, allowing you to develop locally.  I tried doing this as a script, but couldn't seem to get the loop right.

FWIW, I feel like `$HOME/.mrm` should recognize `mrm-task-XXXX` as well, so we don't have to strip that off, but helm's discretion.