### PR TITLE
chore: fix `homepage` links in all the package.json

### DIFF
--- a/packages/mrm-preset-default/package.json
+++ b/packages/mrm-preset-default/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-preset-default",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-preset-default#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-ci/package.json
+++ b/packages/mrm-task-ci/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-ci",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-ci#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-codecov/package.json
+++ b/packages/mrm-task-codecov/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-codecov",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-codecov#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-contributing/package.json
+++ b/packages/mrm-task-contributing/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-contributing",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-contributing#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-dependabot/package.json
+++ b/packages/mrm-task-dependabot/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-dependabot",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-dependabot#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-editorconfig/package.json
+++ b/packages/mrm-task-editorconfig/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-editorconfig",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-editorconfig#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-eslint/package.json
+++ b/packages/mrm-task-eslint/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-eslint",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-eslint#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-gitignore/package.json
+++ b/packages/mrm-task-gitignore/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-gitignore",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-gitignore#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-gitter/package.json
+++ b/packages/mrm-task-gitter/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-gitter",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-gitter#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-jest/package.json
+++ b/packages/mrm-task-jest/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-jest",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-jest#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-license/package.json
+++ b/packages/mrm-task-license/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-license",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-license#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-lint-staged/package.json
+++ b/packages/mrm-task-lint-staged/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-lint-staged",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-lint-staged#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-package/package.json
+++ b/packages/mrm-task-package/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-package",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-package#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-prettier/package.json
+++ b/packages/mrm-task-prettier/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-prettier",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-prettier#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-readme/package.json
+++ b/packages/mrm-task-readme/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-readme",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-readme#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-semantic-release/package.json
+++ b/packages/mrm-task-semantic-release/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-semantic-release",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-semantic-release#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-styleguidist/package.json
+++ b/packages/mrm-task-styleguidist/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-styleguidist",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-styleguidist#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-stylelint/package.json
+++ b/packages/mrm-task-stylelint/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-stylelint",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-stylelint#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-travis/package.json
+++ b/packages/mrm-task-travis/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "https://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-travis",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-travis#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {

--- a/packages/mrm-task-typescript/package.json
+++ b/packages/mrm-task-typescript/package.json
@@ -6,7 +6,7 @@
     "name": "Artem Sapegin",
     "url": "http://sapegin.me"
   },
-  "homepage": "https://github.com/sapegin/mrm/packages/mrm-task-typescript",
+  "homepage": "https://github.com/sapegin/mrm/tree/master/packages/mrm-task-typescript#readme",
   "repository": "sapegin/mrm",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Hey ! 
Thanks for MRM ! Super useful tool 🚀

I just fixed the "homepage" link of each package.json, so that the link displayed from the npm site does not redirect to a 404 page anymore, example : 

https://www.npmjs.com/package/mrm-task-lint-staged ( click on the "homepage" link )