### PR TITLE
Update runPnpm install and uninstall

### DIFF
--- a/packages/mrm-core/src/__tests__/npm.spec.js
+++ b/packages/mrm-core/src/__tests__/npm.spec.js
@@ -87,7 +87,7 @@ describe('install()', () => {
 		install(modules, { pnpm: true }, spawn);
 		expect(spawn).toBeCalledWith(
 			expect.stringMatching(/pnpm(\.cmd)?/),
-			['install', '--save-dev', 'eslint@latest', 'babel-core@latest'],
+			['add', '--save-dev', 'eslint@latest', 'babel-core@latest'],
 			options
 		);
 	});
@@ -136,7 +136,7 @@ describe('install()', () => {
 		install(modules, { dev: false, pnpm: true }, spawn);
 		expect(spawn).toBeCalledWith(
 			expect.stringMatching(/pnpm(\.cmd)?/),
-			['install', '--save', 'eslint@latest', 'babel-core@latest'],
+			['add', '--save-prod', 'eslint@latest', 'babel-core@latest'],
 			options
 		);
 	});
@@ -429,7 +429,7 @@ describe('uninstall()', () => {
 		uninstall(modules, { pnpm: true }, spawn);
 		expect(spawn).toBeCalledWith(
 			expect.stringMatching(/npm(\.cmd)?/),
-			['uninstall', '--save-dev', 'eslint', 'babel-core'],
+			['remove', '--save-dev', 'eslint', 'babel-core'],
 			options
 		);
 	});

--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -181,9 +181,10 @@ function runYarnBerry(deps, options = {}, exec) {
  * @param {Function} [exec]
  */
 function runPnpm(deps, options = {}, exec) {
-	const add = ['install', options.dev ? '--save-dev' : '--save'];
-	const remove = ['uninstall'];
-	const args = (options.remove ? remove : add).concat(deps);
+	const args = [
+		options.remove ? 'remove' : 'add',
+		options.dev ? '--save-dev' : '--save-prod',
+	].concat(deps);
 
 	return execCommand(exec, 'pnpm', args, {
 		stdio: options.stdio === undefined ? 'inherit' : options.stdio,

--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -181,10 +181,9 @@ function runYarnBerry(deps, options = {}, exec) {
  * @param {Function} [exec]
  */
 function runPnpm(deps, options = {}, exec) {
-	const args = [
-		options.remove ? 'uninstall' : 'install',
-		options.dev ? '--save-dev' : '--save',
-	].concat(deps);
+	const add = ['install', options.dev ? '--save-dev' : '--save'];
+	const remove = ['uninstall'];
+	const args = (options.remove ? remove : add).concat(deps);
 
 	return execCommand(exec, 'pnpm', args, {
 		stdio: options.stdio === undefined ? 'inherit' : options.stdio,


### PR DESCRIPTION
# Purpose

Noticed an issue where `runPnpm` was passing `--save` in the args of `uninstall`, causing it to error out due to an unrecognized flag.

Decided to have a look through the pnpm cli docs and update the `runPnpm` args generation.

# Changes

uninstall -> remove: `uninstall` is an alias for `remove` so might as well just use `remove`

install -> add: `add` is the equivalent of npm's `install` where it installs a package and any packages that it depends on...

--save -> --save-prod: `--save` does not exist as a flag for pnpm `remove`, `--save-dev` and `--save-prod` are documented flags for `add` and `remove`

# Sources

* https://docs.npmjs.com/cli/v8/commands/npm-install#save
* https://pnpm.io/cli/install
* https://pnpm.io/cli/add
* https://pnpm.io/cli/remove

