### PR TITLE
chore(mrm-task-lint-staged): Update Readme.md

### DIFF
--- a/packages/mrm-task-lint-staged/Readme.md
+++ b/packages/mrm-task-lint-staged/Readme.md
@@ -22,7 +22,7 @@ npx mrm lint-staged
 
 ## Options
 
-See [Mrm docs](../../docs/Getting_started.md) and [lint-staged docs](https://github.com/okonet/lint-staged/blob/master/README.md) for more details.
+See [Mrm docs](../../docs/Getting_started.md) and [lint-staged docs](https://github.com/okonet/lint-staged/blob/master/README.md#-lint-staged---) for more details.
 
 ### `lintStagedRules` (default: infer)
 


### PR DESCRIPTION
The link to the lint-staged docs is broken, on the website page (https://mrm.js.org/docs/mrm-task-lint-staged).

It redirects to: https://github.com/okonet/lint-staged/blob/master/readme

So fix it up with: https://github.com/okonet/lint-staged/blob/master/README.md#-lint-staged---