### PR TITLE
fix(execCommand): remove appending of .cmd when using Windows

### DIFF
--- a/packages/mrm-core/src/util/execCommand.js
+++ b/packages/mrm-core/src/util/execCommand.js
@@ -1,6 +1,5 @@
 // @ts-check
 const { spawnSync } = require('child_process');
-const isWindows = require('./isWindows');
 const escapeArguments = require('./escapeArguments');
 
 /**
@@ -8,11 +7,10 @@ const escapeArguments = require('./escapeArguments');
  *
  * @param {Function} exec
  * @param {string} command
- * @param  {...any} args
+ * @param {...any} args
  */
 function execCommand(exec, command, ...args) {
 	exec = exec || spawnSync;
-	command = isWindows() ? `${command}.cmd` : command;
 	args[0] = escapeArguments(args[0]);
 
 	return exec(command, ...args);

--- a/packages/mrm-core/src/util/isWindows.js
+++ b/packages/mrm-core/src/util/isWindows.js
@@ -2,7 +2,7 @@
 const os = require('os');
 
 /**
- * Rerturn true when we are in a win32 environement
+ * Return true when we are in a win32 environment
  */
 function isWindows() {
 	return os.platform() === 'win32';


### PR DESCRIPTION
Hey there! 👋🏻 

There is no need to append `.cmd` by code at the end of the command to execute it on Windows. Windows will do it automatically (appending `.cmd` and `.exe` to see if the command exists in the `PATH`).

On top of that, forcing the command to have `.cmd` may break codes that do not have a `.cmd` script.
For example, the `pnpm` Windows installation creates a `.exe` file, making an `Error: spawn pnpm.cmd ENOENT` when using `mrm`.

Here is the command executed inside the Node.js REPL on Windows and without the `.cmd`:
![](https://user-images.githubusercontent.com/2793951/201515636-e62dabff-71b0-4b2f-a4c4-710d046fe0e9.png)
