### PR TITLE
feat: support installing packages at the root of a pnpm workspace

### DIFF
--- a/packages/mrm-core/src/npm.js
+++ b/packages/mrm-core/src/npm.js
@@ -184,7 +184,7 @@ function runPnpm(deps, options = {}, exec) {
 	const args = [
 		options.remove ? 'remove' : 'add',
 		options.dev ? '--save-dev' : '--save-prod',
-		isInPnpmWorkspaceRoot() ? '-W' : '',
+		isInPnpmWorkspaceRoot() ? '--ignore-workspace-root-check' : '',
 	].concat(deps);
 
 	return execCommand(exec, 'pnpm', args, {


### PR DESCRIPTION
Directly adding a dependency at the root of a pnpm workspace would fail, unless run with an aditional flag. See https://pnpm.io/cli/add#--ignore-workspace-root-check