### PR TITLE
Add XDG base directory spec support

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -45,6 +45,8 @@ module.exports = function task(config) {
 - `<DIR>/config.json` if `--dir <DIR>` command line option was passed
 - `$HOME/dotfiles/mrm/config.json`
 - `$HOME/.mrm/config.json`
+- `$XDG_CONFIG_HOME/mrm/config.json`
+- `$HOME/.config/mrm/config.json`
 
 if you’re passing a `--preset <PRESET>` command line option, then the only task directory will be:
 
@@ -55,6 +57,8 @@ if you’re passing a `--preset <PRESET>` command line option, then the only tas
 - `<DIR>/<TASK>/index.js` if `--dir <DIR>` command line option was passed
 - `$HOME/dotfiles/mrm/<TASK>/index.js`
 - `$HOME/.mrm/<TASK>/index.js`
+- `$XDG_CONFIG_HOME/mrm/<TASK>/index.js`
+- `$HOME/.config/mrm/<TASK>/index.js`
 - `mrm-task-<TASK>/index.js`, where `mrm-task-<TASK>` is an npm package name
 
 if you’re passing a `--preset <PRESET>` command line option, then the only task directory will be:

--- a/docs/Getting_started.md
+++ b/docs/Getting_started.md
@@ -99,20 +99,29 @@ This will ultimately set the `name` config for this single task execution.
 
 ### Config files
 
-Create `~/.mrm/config.json` or `~/dotfiles/mrm/config.json`:
+In Unix systems, you can create a `config.json` file in one of the following directories:
 
-```json5
+- `$HOME/dotfiles/mrm`
+- `$HOME/.mrm`
+- `$XDG_CONFIG_HOME/mrm`
+- `$HOME/.config/mrm`
+
+Example:
+
+```json
 {
-  indent: 'tab', // "tab" or number of spaces
-  readmeFile: 'Readme.md', // Name of readme file
-  licenseFile: 'License.md', // Name of license file
-  aliases: {
+  "indent": "tab", // "tab" or number of spaces
+  "readmeFile": "Readme.md", // Name of readme file
+  "licenseFile": "License.md", // Name of license file
+  "aliases": {
     // Aliases to run multiple tasks at once
-    node: ['license', 'readme', 'editorconfig', 'gitignore'],
+    "node": ["license", "readme", "editorconfig", "gitignore"],
     // You can reference another alias has been defined.
-    frontend: ['node', 'eslint', 'typescript']
+    "frontend": ["node", "eslint", "typescript"]
   }
 }
 ```
+
+> Note: Make sure to delete all comments from the config file.
 
 **When to use:** when you often use the same configuration (usually when you scaffold new projects frequently); when you want to define sets of default task aliases.

--- a/docs/Making_tasks.md
+++ b/docs/Making_tasks.md
@@ -2,7 +2,14 @@
 
 # Making your own tasks
 
-Create either `~/.mrm/<TASK>/index.js` or `~/dotfiles/mrm/<TASK>/index.js`. If `<TASK>` is the same as one of the default tasks your task will override the default one.
+In Unix systems, you can create an `index.js` file in one of the following directories:
+
+- `$HOME/dotfiles/mrm/<TASK>`
+- `$HOME/.mrm/<TASK>`
+- `$XDG_CONFIG_HOME/mrm/<TASK>`
+- `$HOME/.config/mrm/<TASK>`
+
+**Replace** `<TASK>` with the **desired task name**. If `<TASK>` is the same as one of the default tasks, your task will _override_ the default one.
 
 **Tip:** Tasks can be packaged into presets; if you want to share them, see [Making presets](Making_presets.md).
 

--- a/packages/mrm/bin/mrm.js
+++ b/packages/mrm/bin/mrm.js
@@ -29,6 +29,8 @@ const {
 const defaultDirectories = [
 	path.resolve(userHome, 'dotfiles/mrm'),
 	path.resolve(userHome, '.mrm'),
+	path.resolve(process.env.XDG_CONFIG_HOME, 'mrm'),
+	path.resolve(userHome, '.config/mrm'),
 ];
 
 const EXAMPLES = [

--- a/packages/mrm/src/__tests__/index.spec.js
+++ b/packages/mrm/src/__tests__/index.spec.js
@@ -103,9 +103,12 @@ describe('tryFile', () => {
 describe('resolveUsingNpx', () => {
 	it('should install an npm module transparently', async () => {
 		const result = await resolveUsingNpx('yarnhook');
-		expect(result).toMatch(
-			/\.npm\/_npx\/\d*\/lib(64)?\/node_modules\/yarnhook\/index\.js$/
-		);
+		const npmCacheDir = process.env.NPM_CONFIG_CACHE || '.npm';
+		const pattern = `
+			${npmCacheDir}/_npx/\\d*/lib(64)?/node_modules/yarnhook/index.js$
+		`.trim();
+		const regex = new RegExp(pattern);
+		expect(result).toMatch(regex);
 	});
 
 	it('should throw if npm module is not found on the registry', () => {


### PR DESCRIPTION
- fix(test): add `NPM_CONFIG_CACHE` dir support

The 'should install an npm module transparently' test did not account for the possibility that the `NPM_CONFIG_CACHE` environment variable might be set. So, it would fail in that case. The fix includes checking the value of `NPM_CONFIG_CACHE` and using that value if it is set, otherwise defaulting to `.npm` directory.

```
Summary of all failing tests
 FAIL  packages/mrm/src/__tests__/index.spec.js (12.65s)
  ● resolveUsingNpx › should install an npm module transparently

    : Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.Error:

      102 | 
      103 | describe('resolveUsingNpx', () => {
    > 104 |     it('should install an npm module transparently', async () => {
          |     ^
      105 |             const result = await resolveUsingNpx('yarnhook');
      106 |             expect(result).toMatch(
      107 |                     /\.npm\/_npx\/\d*\/lib(64)?\/node_modules\/yarnhook\/index\.js$/

      at new Spec (node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at Suite.<anonymous> (packages/mrm/src/__tests__/index.spec.js:104:2)
      at Object.<anonymous> (packages/mrm/src/__tests__/index.spec.js:103:1)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)

  ● resolveUsingNpx › should throw if npm module is not found on the registry

    expect(received).toMatch(expected)

    Expected pattern: /\.npm\/_npx\/\d*\/lib(64)?\/node_modules\/yarnhook\/index\.js$/
    Received string:  "/Users/mohammed/.cache/npm/_npx/23946/lib/node_modules/yarnhook/index.js"

      104 |     it('should install an npm module transparently', async () => {
      105 |             const result = await resolveUsingNpx('yarnhook');
    > 106 |             expect(result).toMatch(
          |                            ^
      107 |                     /\.npm\/_npx\/\d*\/lib(64)?\/node_modules\/yarnhook\/index\.js$/
      108 |             );
      109 |     });

      at Object.<anonymous> (packages/mrm/src/__tests__/index.spec.js:106:18)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

- feat(config): add XDG base directory spec support

This change enables users to organize their config file according to the XDG Base Directory specification.

- docs(md): add XDG base directory instructions